### PR TITLE
Fix RobustOptimizer for Keras 3 compatibility

### DIFF
--- a/treeflow/vi/optimizers/robust_optimizer.py
+++ b/treeflow/vi/optimizers/robust_optimizer.py
@@ -7,38 +7,33 @@ class RobustOptimizer:  # Pseudo-optimizer
         self.max_retries = max_retries
         self.retries = tf.Variable(0)
 
-    def apply_gradients(self, grads_and_vars, name=None, **kwargs):
-        """Apply gradients to variables.
+    def apply_gradients(self, grads_and_vars, **kwargs):
+        """Apply gradients to variables, skipping the step if any gradient
+        contains NaN.
 
-        Args:
-        grads_and_vars: List of (gradient, variable) pairs as returned by
-            `compute_gradients()`.
-        global_step: Optional `Variable` to increment by one after the
-            variables have been updated.
-        name: Optional name for the returned operation.  Default to the
-            name passed to the `Optimizer` constructor.
+        When NaN gradients are detected, all gradients are zeroed so that
+        the inner optimizer is still called with its expected variables
+        (required by Keras 3) but no parameters are updated, preserving
+        the original skip-step semantics.
         """
         grads_and_vars = list(grads_and_vars)
         grads = [grad for grad, var in grads_and_vars]
+        vars_ = [var for grad, var in grads_and_vars]
         any_nan = tf.reduce_any([tf.reduce_any(tf.math.is_nan(x)) for x in grads])
 
-        def nan_handler():
-            assertion = tf.assert_less(self.retries, self.max_retries)
-            with tf.control_dependencies([assertion]):
-                self.retries.assign_add(1)
-            return tf.zeros(
-                (), dtype=tf.int64
-            )  # apply_gradients returns int64 iteration
+        # Zero all gradients if any NaN — effectively skips the step
+        safe_grads = [tf.where(any_nan, tf.zeros_like(g), g) for g in grads]
 
-        def update_handler():
-            self.retries.assign(0)
-            return self.inner.apply_gradients(grads_and_vars, **kwargs)
-
-        return tf.cond(
-            any_nan,
-            nan_handler,
-            update_handler,
+        # Track consecutive NaN steps (assert before incrementing,
+        # matching original semantics)
+        tf.debugging.assert_less(
+            self.retries,
+            self.max_retries,
+            message="Too many consecutive NaN gradient steps",
         )
+        self.retries.assign(tf.where(any_nan, self.retries + 1, 0))
+
+        return self.inner.apply_gradients(zip(safe_grads, vars_), **kwargs)
 
 
 __all__ = ["RobustOptimizer"]


### PR DESCRIPTION
## Summary

- Keras 3 added strict variable validation in optimizers: `apply_gradients` rejects variables not seen during the initial build/trace
- The old `tf.cond` approach traces both branches — since `nan_handler` never calls `apply_gradients`, the optimizer doesn't register the variables, causing `ValueError: Unknown variable` on subsequent calls
- Fix: replace `tf.cond` with `tf.where` to zero all gradients when any NaN is detected, then always call `self.inner.apply_gradients`. This preserves the skip-step semantics (zero gradients = no parameter movement) while ensuring the optimizer always sees the same variables

## Behavioural difference

Not bit-identical to the original when using Adam. On NaN steps:

| | Original (`tf.cond`) | New (`tf.where` zeros) |
|---|---|---|
| Parameter update | None (optimizer not called) | None (zero gradients) |
| Adam momentum | Frozen | Decays by β₁ (10% per step) |
| Adam variance | Frozen | Decays by β₂ (0.1% per step) |
| Step counter | Unchanged | Increments |

This only matters during NaN gradient bursts, which should be rare (typically only in early VI iterations with extreme initial values). A burst of 10 consecutive NaN steps would reduce Adam momentum to ~35% vs preserved in the original. Recovery is fast once valid gradients resume.

For SGD, the behaviour is identical.

## Test plan

- [x] All 6 existing `test_robust_optimizer.py` tests pass
- [ ] Compare VI convergence (ELBO trajectory) on carnivores example with old vs new implementation
- [ ] Check for NaN gradient frequency in typical runs