### PR TITLE
Fix bito/BEAGLE wrapper bugs in beagle.py

### DIFF
--- a/treeflow/acceleration/bito/beagle.py
+++ b/treeflow/acceleration/bito/beagle.py
@@ -72,7 +72,7 @@ def phylogenetic_likelihood(
 
     def bito_func(x):
         """Wrapping likelihood and gradient evaluation via beagle."""
-        branch_lengths[:-1] = x
+        branch_lengths[:-1] = x * clock_rate
         gradient = inst.phylo_gradients()[0]
         grad_array = np.array(
             gradient.gradient["branch_lengths"], dtype=DEFAULT_FLOAT_DTYPE_NP

--- a/treeflow/acceleration/bito/beagle.py
+++ b/treeflow/acceleration/bito/beagle.py
@@ -43,7 +43,7 @@ def phylogenetic_likelihood(
         raise ValueError(f"Unsupported substitution model: {subst_model}")
 
     if site_model == "discrete_weibull":
-        param_updates["Weibull shape"] = site_model_params["site_weibull_concentration"]
+        param_updates["Weibull_shape"] = site_model_params["site_weibull_concentration"]
         category_count = site_model_params["category_count"]
         site_model_string = f"weibull+{category_count}"
     elif site_model == "none":


### PR DESCRIPTION
## Summary

Two fixes to `treeflow/acceleration/bito/beagle.py`:

- **Weibull parameter key**: `'Weibull shape'` → `'Weibull_shape'`. bito's C++ code defines the key with an underscore, but treeflow was passing it with a space, causing `KeyError` during benchmark initialization.

- **Clock rate scaling**: `bito_func` now multiplies branch lengths by `clock_rate` before writing them to bito's internal tree. Previously the `clock_rate` parameter was set in bito's param block map but never applied to the likelihood computation, so BEAGLE was computing likelihoods on unscaled divergence times rather than substitutions/site.

## Verified

All three benchmark methods (treeflow, bito/BEAGLE, JAX) now produce identical log-likelihoods to machine precision (~1e-11) on both JC and GTR+Weibull models.