### PR TITLE
Enhance CI workflow for Docker image testing with pytest

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -18,7 +18,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  test:
+  pytest:
     needs: build
     runs-on: ubuntu-latest
     strategy:
@@ -42,3 +42,12 @@ jobs:
           cache-from: type=gha
       - name: Run pytest (${{ matrix.name }})
         run: docker run --rm --workdir /app treeflow-test:ci pytest ${{ matrix.pytest_args }}
+
+  test:
+    if: always()
+    needs: pytest
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          result="${{ needs.pytest.result }}"
+          if [[ "$result" == "success" ]]; then exit 0; else exit 1; fi

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -6,12 +6,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build test image
+        uses: docker/build-push-action@v6
         with:
-          python-version: "3.10"
-          cache: pip
-      - name: Install package and test dependencies
-        run: pip install -e ".[test]"
-      - name: Run tests
-        run: pytest
+          context: .
+          platforms: linux/amd64
+          target: test
+          load: true
+          tags: treeflow-test:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Run pytest
+        run: docker run --rm --workdir /app treeflow-test:ci pytest

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -27,7 +27,7 @@ jobs:
           - name: unit
             pytest_args: ""
           - name: cli
-            pytest_args: --override-ini="addopts=" -m cli
+            pytest_args: --override-ini="addopts=" -m "cli and not bito"
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -5,6 +5,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: unit
+            pytest_args: ""
+          - name: cli
+            pytest_args: --override-ini="addopts=" -m cli
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -18,5 +25,5 @@ jobs:
           tags: treeflow-test:ci
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - name: Run pytest
-        run: docker run --rm --workdir /app treeflow-test:ci pytest
+      - name: Run pytest (${{ matrix.name }})
+        run: docker run --rm --workdir /app treeflow-test:ci pytest ${{ matrix.pytest_args }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -3,7 +3,23 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build and cache test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          target: test
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   test:
+    needs: build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -15,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
-      - name: Build test image
+      - name: Load test image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -24,6 +40,5 @@ jobs:
           load: true
           tags: treeflow-test:ci
           cache-from: type=gha
-          cache-to: type=gha,mode=max
       - name: Run pytest (${{ matrix.name }})
         run: docker run --rm --workdir /app treeflow-test:ci pytest ${{ matrix.pytest_args }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,3 +60,6 @@ USER root
 RUN --mount=type=cache,target=/root/.cache/pip \
     python -m pip install ".[test]"
 USER appuser
+
+# Final runtime stage — default build output (no test dependencies)  
+FROM base AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,3 +53,10 @@ EXPOSE 8888
 
 # Run the application.
 CMD ["jupyter", "lab", "--ip=0.0.0.0", "--no-browser"]
+
+# Test stage — not pushed to registry
+FROM base AS test
+USER root
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python -m pip install ".[test]"
+USER appuser

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,5 +54,6 @@ benchmark =
 test =
     pandas>=1.3.5
     pytest>=7.1.2
+    allpairspy>=2.5.0
 accelerated =
     bito

--- a/test/cli/test_benchmark.py
+++ b/test/cli/test_benchmark.py
@@ -11,13 +11,7 @@ def benchmark_output_path(tmp_path):
     return tmp_path / "treeflow-benchmark.csv"
 
 
-@pytest.mark.parametrize(["use_bito", "gtr"], [
-    pytest.param(True, False, marks=pytest.mark.bito),
-    (False, True),
-])
-def test_benchmark(
-    hello_fasta_file, hello_newick_file, benchmark_output_path, use_bito, gtr
-):
+def _run_benchmark(hello_fasta_file, hello_newick_file, benchmark_output_path, use_bito, gtr):
     runner = CliRunner()
     args = [
         "-i",
@@ -39,3 +33,12 @@ def test_benchmark(
         catch_exceptions=False,
     )
     print(res)
+
+
+def test_benchmark(hello_fasta_file, hello_newick_file, benchmark_output_path):
+    _run_benchmark(hello_fasta_file, hello_newick_file, benchmark_output_path, use_bito=False, gtr=True)
+
+
+@pytest.mark.bito
+def test_benchmark_bito(hello_fasta_file, hello_newick_file, benchmark_output_path):
+    _run_benchmark(hello_fasta_file, hello_newick_file, benchmark_output_path, use_bito=True, gtr=False)

--- a/test/cli/test_benchmark.py
+++ b/test/cli/test_benchmark.py
@@ -32,6 +32,7 @@ def _run_benchmark(hello_fasta_file, hello_newick_file, benchmark_output_path, u
         args,
         catch_exceptions=False,
     )
+    assert res.exit_code == 0
     print(res)
 
 

--- a/test/cli/test_ml_cli.py
+++ b/test/cli/test_ml_cli.py
@@ -1,51 +1,70 @@
 import pytest
+from allpairspy import AllPairs
 from click.testing import CliRunner
-
-pytestmark = pytest.mark.cli
 from treeflow.cli.ml import treeflow_ml
 
+pytestmark = pytest.mark.cli
 
-@pytest.mark.parametrize("include_init_values", [True, False])
+_DATASETS = [
+    ("hello.nwk", "hello.fasta", False),
+    ("wnv.nwk", "wnv.fasta", True),
+]
+_MODEL_FILES = [None, "model.yaml"]
+_INIT = [True, False]
+
+_CASES = list(AllPairs([_DATASETS, _MODEL_FILES, _INIT]))
+
+
+def _case_id(case):
+    dataset, model_filename, include_init_values = case
+    return "-".join([
+        dataset[0].removesuffix(".nwk"),
+        model_filename.removesuffix(".yaml") if model_filename else "no-model",
+        "init" if include_init_values else "no-init",
+    ])
+
+
+@pytest.mark.parametrize(
+    "dataset,model_filename,include_init_values",
+    _CASES,
+    ids=[_case_id(c) for c in _CASES],
+)
 def test_ml_cli(
-    newick_fasta_file_dated,
-    include_init_values,
-    model_file,
+    test_data_dir,
     samples_output_path,
     tree_samples_output_path,
     trace_output_path,
+    dataset,
+    model_filename,
+    include_init_values,
 ):
     import pandas as pd
     import dendropy
 
-    newick_file, fasta_file, dated = newick_fasta_file_dated
+    newick_filename, fasta_filename, _ = dataset
+    newick_file = str(test_data_dir / newick_filename)
+    fasta_file = str(test_data_dir / fasta_filename)
+    model_file = str(test_data_dir / model_filename) if model_filename is not None else None
+
     runner = CliRunner()
     args = [
-        "-i",
-        str(fasta_file),
-        "-t",
-        str(newick_file),
-        "-n",
-        str(10),
-        "--variables-output",
-        str(samples_output_path),
-        "--tree-output",
-        str(tree_samples_output_path),
-        "--trace-output",
-        str(trace_output_path),
+        "-i", fasta_file,
+        "-t", newick_file,
+        "-n", str(10),
+        "--variables-output", str(samples_output_path),
+        "--tree-output", str(tree_samples_output_path),
+        "--trace-output", str(trace_output_path),
     ]
     if model_file is None:
         init_values_string = "clock_rate=0.01"
     else:
-        args = args + ["-m", model_file]
+        args += ["-m", model_file]
         init_values_string = "pop_size=10"
 
     if include_init_values:
-        args = args + ["--init-values", init_values_string]
-    res = runner.invoke(
-        treeflow_ml,
-        args,
-        catch_exceptions=False,
-    )
+        args += ["--init-values", init_values_string]
+
+    res = runner.invoke(treeflow_ml, args, catch_exceptions=False)
     assert res.exit_code == 0
     print(res.stdout)
     samples = pd.read_csv(samples_output_path)

--- a/test/cli/test_vi.py
+++ b/test/cli/test_vi.py
@@ -1,61 +1,85 @@
 import pytest
-from tensorflow.python.keras.optimizer_v2.adam import Adam
-
-pytestmark = pytest.mark.cli
+from allpairspy import AllPairs
 from treeflow.cli.vi import treeflow_vi, approximation_builders
 from click.testing import CliRunner
 
+pytestmark = pytest.mark.cli
 
-@pytest.mark.parametrize("include_init_values", [True, False])
-@pytest.mark.parametrize("progress_bar", [True, False])
+_DATASETS = [
+    ("hello.nwk", "hello.fasta", False),
+    ("wnv.nwk", "wnv.fasta", True),
+]
+_MODEL_FILES = [None, "model.yaml", "yule-model.yaml"]
+_APPROX = list(approximation_builders.keys())
+_PROGRESS = [True, False]
+_INIT = [True, False]
+_CONVERGENCE = [None, "nonfinite"]
+
+_INIT_VALUES = {
+    None: "clock_rate=0.01",
+    "model.yaml": "pop_size=10",
+    "yule-model.yaml": "birth_rate=2,frequencies=0.24|0.23|0.26|0.27",
+}
+
+_CASES = list(AllPairs([_DATASETS, _MODEL_FILES, _APPROX, _PROGRESS, _INIT, _CONVERGENCE]))
+
+
+def _case_id(case):
+    dataset, model_filename, approx, progress_bar, include_init_values, convergence = case
+    return "-".join([
+        dataset[0].removesuffix(".nwk"),
+        model_filename.removesuffix(".yaml") if model_filename else "no-model",
+        approx,
+        "progress" if progress_bar else "no-progress",
+        "init" if include_init_values else "no-init",
+        convergence if convergence else "default-convergence",
+    ])
+
+
 @pytest.mark.parametrize(
-    "variational_approximation", list(approximation_builders.keys())
+    "dataset,model_filename,variational_approximation,progress_bar,include_init_values,convergence_criterion",
+    _CASES,
+    ids=[_case_id(c) for c in _CASES],
 )
 def test_vi(
-    newick_fasta_file_dated,
-    include_init_values,
-    model_file,
+    test_data_dir,
     samples_output_path,
     tree_samples_output_path,
-    progress_bar,
+    dataset,
+    model_filename,
     variational_approximation,
+    progress_bar,
+    include_init_values,
+    convergence_criterion,
 ):
     import pandas as pd
     import dendropy
 
-    newick_file, fasta_file, dated = newick_fasta_file_dated
+    newick_filename, fasta_filename, _ = dataset
+    newick_file = str(test_data_dir / newick_filename)
+    fasta_file = str(test_data_dir / fasta_filename)
+    model_file = str(test_data_dir / model_filename) if model_filename is not None else None
+
     runner = CliRunner()
     n_output_samples = 10
     args = [
-        "-i",
-        str(fasta_file),
-        "-t",
-        str(newick_file),
-        "-n",
-        str(10),
-        "-va",
-        variational_approximation,
-        "--samples-output",
-        str(samples_output_path),
-        "--tree-samples-output",
-        str(tree_samples_output_path),
-        "--n-output-samples",
-        str(n_output_samples),
+        "-i", fasta_file,
+        "-t", newick_file,
+        "-n", str(10),
+        "-va", variational_approximation,
+        "--samples-output", str(samples_output_path),
+        "--tree-samples-output", str(tree_samples_output_path),
+        "--n-output-samples", str(n_output_samples),
         "--progress-bar" if progress_bar else "--no-progress-bar",
     ]
-    if model_file is None:
-        init_values_string = "clock_rate=0.01"
-    else:
-        args = args + ["-m", model_file]
-        init_values_string = "pop_size=10"
-
+    if model_file is not None:
+        args += ["-m", model_file]
     if include_init_values:
-        args = args + ["--init-values", init_values_string]
-    res = runner.invoke(
-        treeflow_vi,
-        args,
-        catch_exceptions=False,
-    )
+        args += ["--init-values", _INIT_VALUES[model_filename]]
+    if convergence_criterion is not None:
+        args += ["--convergence-criterion", convergence_criterion]
+
+    res = runner.invoke(treeflow_vi, args, catch_exceptions=False)
     assert res.exit_code == 0
     print(res.stdout)
     samples = pd.read_csv(samples_output_path)
@@ -63,50 +87,3 @@ def test_vi(
 
     trees = dendropy.TreeList.get(path=tree_samples_output_path, schema="nexus")
     assert len(trees) == n_output_samples
-
-
-@pytest.mark.parametrize("include_init_values", [True, False])
-def test_vi_yule(
-    test_data_dir, hello_newick_file, hello_fasta_file, include_init_values
-):
-    model_file = str(test_data_dir / "yule-model.yaml")
-    init_values_string = "birth_rate=2,frequencies=0.24|0.23|0.26|0.27"
-    runner = CliRunner()
-    args = [
-        "-i",
-        str(hello_fasta_file),
-        "-t",
-        str(hello_newick_file),
-        "-n",
-        str(10),
-        "-m",
-        model_file,
-    ]
-    if include_init_values:
-        args = args + ["--init-values", init_values_string]
-    res = runner.invoke(
-        treeflow_vi,
-        args,
-        catch_exceptions=False,
-    )
-    print(res.stdout)
-
-
-def test_vi_nonfinite_convergence(hello_newick_file, hello_fasta_file):
-    runner = CliRunner()
-    args = [
-        "-i",
-        str(hello_fasta_file),
-        "-t",
-        str(hello_newick_file),
-        "-n",
-        str(10),
-        "--convergence-criterion",
-        "nonfinite",
-    ]
-    res = runner.invoke(
-        treeflow_vi,
-        args,
-        catch_exceptions=False,
-    )
-    print(res.stdout)


### PR DESCRIPTION
This pull request introduces significant improvements to the testing workflow by refactoring how tests are run in CI and how test dependencies are managed. The main changes include splitting the Docker build into multiple stages for test and runtime environments, updating the GitHub Actions workflow to use Docker for testing, and refactoring benchmark test parametrization for clarity and maintainability.

**CI/CD Pipeline Improvements:**

* Refactored the `.github/workflows/pytest.yaml` workflow to build a dedicated Docker test image before running tests, and to run tests inside containers using Docker, ensuring consistency between local and CI environments. The workflow now uses a build matrix for different test types and leverages Docker layer caching for faster builds.

* Updated the `Dockerfile` to add a new `test` stage that installs test dependencies and is used only for testing (not pushed to the registry), and a `runtime` stage for production use without test dependencies. This separation ensures smaller, more secure production images and efficient CI builds.

**Test Code Refactoring:**

* Refactored the benchmark test in `test/cli/test_benchmark.py` by extracting the test logic into a helper function (`_run_benchmark`) and splitting the original parameterized test into two explicit test cases: one for the standard run and one for the `bito`-marked run. This improves test clarity and makes it easier to run or skip specific test cases. [[1]](diffhunk://#diff-a13347b4b9f5eafb023c1866015cc1be31ca82a0baca91fddea3e791e07ed7b7L14-R14) [[2]](diffhunk://#diff-a13347b4b9f5eafb023c1866015cc1be31ca82a0baca91fddea3e791e07ed7b7R36-R44)