### PR TITLE
HMC

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ console_scripts =
     treeflow_benchmark = treeflow.cli.benchmark:treeflow_benchmark
     treeflow_vi = treeflow.cli.vi:treeflow_vi
     treeflow_ml = treeflow.cli.ml:treeflow_ml
+    treeflow_hmc = treeflow.cli.hmc:treeflow_hmc
 
 
 [options.extras_require]

--- a/test/cli/test_hmc_cli.py
+++ b/test/cli/test_hmc_cli.py
@@ -1,0 +1,82 @@
+import pytest
+from allpairspy import AllPairs
+from treeflow.cli.hmc import treeflow_hmc, KERNEL_CHOICES
+from click.testing import CliRunner
+
+pytestmark = pytest.mark.cli
+
+_DATASETS = [
+    ("hello.nwk", "hello.fasta"),
+    ("wnv.nwk", "wnv.fasta"),
+]
+_MODEL_FILES = [None, "model.yaml"]
+_KERNELS = KERNEL_CHOICES
+_INIT = [True, False]
+
+_INIT_VALUES = {
+    None: "clock_rate=0.01",
+    "model.yaml": "pop_size=10",
+}
+
+_CASES = list(AllPairs([_DATASETS, _MODEL_FILES, _KERNELS, _INIT]))
+
+
+def _case_id(case):
+    dataset, model_filename, kernel, include_init_values = case
+    return "-".join([
+        dataset[0].removesuffix(".nwk"),
+        model_filename.removesuffix(".yaml") if model_filename else "no-model",
+        kernel,
+        "init" if include_init_values else "no-init",
+    ])
+
+
+@pytest.mark.parametrize(
+    "dataset,model_filename,kernel,include_init_values",
+    _CASES,
+    ids=[_case_id(c) for c in _CASES],
+)
+def test_hmc(
+    test_data_dir,
+    samples_output_path,
+    tree_samples_output_path,
+    dataset,
+    model_filename,
+    kernel,
+    include_init_values,
+):
+    import pandas as pd
+    import dendropy
+
+    newick_filename, fasta_filename = dataset
+    newick_file = str(test_data_dir / newick_filename)
+    fasta_file = str(test_data_dir / fasta_filename)
+    model_file = str(test_data_dir / model_filename) if model_filename is not None else None
+
+    runner = CliRunner()
+    num_results = 10
+    args = [
+        "-i", fasta_file,
+        "-t", newick_file,
+        "-n", str(num_results),
+        "--num-burnin-steps", str(3),
+        "--num-adaptation-steps", str(3),
+        "--num-leapfrog-steps", str(3),
+        "--kernel", kernel,
+        "--samples-output", str(samples_output_path),
+        "--tree-samples-output", str(tree_samples_output_path),
+    ]
+    if model_file is not None:
+        args += ["-m", model_file]
+    if include_init_values:
+        args += ["--init-values", _INIT_VALUES[model_filename]]
+
+    res = runner.invoke(treeflow_hmc, args, catch_exceptions=False)
+    assert res.exit_code == 0, res.stdout
+    print(res.stdout)
+
+    samples = pd.read_csv(samples_output_path)
+    assert samples.shape[0] == num_results
+
+    trees = dendropy.TreeList.get(path=tree_samples_output_path, schema="nexus")
+    assert len(trees) == num_results

--- a/test/vi/test_hmc.py
+++ b/test/vi/test_hmc.py
@@ -1,0 +1,133 @@
+import pytest
+import yaml
+import tensorflow as tf
+from treeflow.model.phylo_model import (
+    phylo_model_to_joint_distribution,
+    PhyloModel,
+    DEFAULT_TREE_VAR_NAME,
+)
+from treeflow.vi.hmc import fit_fixed_topology_hmc, KERNEL_HMC, KERNEL_NUTS
+from treeflow.tree.rooted.tensorflow_rooted_tree import TensorflowRootedTree
+
+NUM_RESULTS = 5
+NUM_BURNIN = 3
+
+
+@pytest.mark.parametrize("kernel", [KERNEL_HMC, KERNEL_NUTS])
+def test_fit_fixed_topology_hmc_sample_shape(
+    actual_model_file, hello_tensor_tree, hello_alignment, kernel
+):
+    with open(actual_model_file) as f:
+        model_dict = yaml.safe_load(f)
+    phylo_model = PhyloModel(model_dict)
+    dist = phylo_model_to_joint_distribution(phylo_model, hello_tensor_tree, hello_alignment)
+
+    encoded_sequences = hello_alignment.get_encoded_sequence_tensor(
+        hello_tensor_tree.taxon_set
+    )
+    pinned = dist.experimental_pin(alignment=encoded_sequences)
+
+    result = fit_fixed_topology_hmc(
+        model=pinned,
+        topologies={DEFAULT_TREE_VAR_NAME: hello_tensor_tree.topology},
+        num_results=NUM_RESULTS,
+        num_burnin_steps=NUM_BURNIN,
+        num_adaptation_steps=NUM_BURNIN,
+        step_size=0.01,
+        num_leapfrog_steps=3,
+        kernel=kernel,
+    )
+
+    samples = result.samples
+    # Samples should be a structured object from the model bijector
+    # The tree variable should be a TensorflowRootedTree with batch dim
+    flat_names = pinned._flat_resolve_names()
+    flat_samples = pinned._model_flatten(samples)
+    samples_dict = dict(zip(flat_names, flat_samples))
+
+    assert DEFAULT_TREE_VAR_NAME in samples_dict
+    tree_samples = samples_dict[DEFAULT_TREE_VAR_NAME]
+    assert isinstance(tree_samples, TensorflowRootedTree)
+    assert tree_samples.node_heights.shape[0] == NUM_RESULTS
+
+    # Non-tree samples should have correct batch shape
+    for name, sample in samples_dict.items():
+        if name != DEFAULT_TREE_VAR_NAME:
+            assert sample.shape[0] == NUM_RESULTS, (
+                f"Variable '{name}' has wrong batch shape: {sample.shape}"
+            )
+
+
+def test_fit_fixed_topology_hmc_samples_finite(
+    actual_model_file, hello_tensor_tree, hello_alignment
+):
+    with open(actual_model_file) as f:
+        model_dict = yaml.safe_load(f)
+    phylo_model = PhyloModel(model_dict)
+    dist = phylo_model_to_joint_distribution(phylo_model, hello_tensor_tree, hello_alignment)
+
+    encoded_sequences = hello_alignment.get_encoded_sequence_tensor(
+        hello_tensor_tree.taxon_set
+    )
+    pinned = dist.experimental_pin(alignment=encoded_sequences)
+
+    result = fit_fixed_topology_hmc(
+        model=pinned,
+        topologies={DEFAULT_TREE_VAR_NAME: hello_tensor_tree.topology},
+        num_results=NUM_RESULTS,
+        num_burnin_steps=NUM_BURNIN,
+        num_adaptation_steps=NUM_BURNIN,
+        step_size=0.01,
+        num_leapfrog_steps=3,
+    )
+
+    flat_names = pinned._flat_resolve_names()
+    flat_samples = pinned._model_flatten(result.samples)
+    samples_dict = dict(zip(flat_names, flat_samples))
+
+    # Check that all sampled tensors are finite
+    for name, sample in samples_dict.items():
+        if isinstance(sample, TensorflowRootedTree):
+            assert tf.reduce_all(tf.math.is_finite(sample.node_heights)), (
+                f"Tree node_heights contain non-finite values"
+            )
+        else:
+            assert tf.reduce_all(tf.math.is_finite(sample)), (
+                f"Variable '{name}' contains non-finite values"
+            )
+
+
+def test_fit_fixed_topology_hmc_with_init_state(
+    actual_model_file, hello_tensor_tree, hello_alignment
+):
+    with open(actual_model_file) as f:
+        model_dict = yaml.safe_load(f)
+    phylo_model = PhyloModel(model_dict)
+    dist = phylo_model_to_joint_distribution(phylo_model, hello_tensor_tree, hello_alignment)
+
+    encoded_sequences = hello_alignment.get_encoded_sequence_tensor(
+        hello_tensor_tree.taxon_set
+    )
+    pinned = dist.experimental_pin(alignment=encoded_sequences)
+
+    init_state = {DEFAULT_TREE_VAR_NAME: hello_tensor_tree}
+
+    result = fit_fixed_topology_hmc(
+        model=pinned,
+        topologies={DEFAULT_TREE_VAR_NAME: hello_tensor_tree.topology},
+        num_results=NUM_RESULTS,
+        num_burnin_steps=NUM_BURNIN,
+        num_adaptation_steps=NUM_BURNIN,
+        step_size=0.01,
+        num_leapfrog_steps=3,
+        init_state=init_state,
+    )
+
+    flat_names = pinned._flat_resolve_names()
+    flat_samples = pinned._model_flatten(result.samples)
+    assert len(flat_samples) == len(flat_names)
+    for sample in flat_samples:
+        if hasattr(sample, "node_heights"):
+            assert sample.node_heights.shape[0] == NUM_RESULTS
+        else:
+            assert sample.shape[0] == NUM_RESULTS

--- a/treeflow/cli/hmc.py
+++ b/treeflow/cli/hmc.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import click
+import yaml
+import typing as tp
+import tensorflow as tf
+from treeflow import DEFAULT_FLOAT_DTYPE_TF
+from treeflow.model.phylo_model import (
+    phylo_model_to_joint_distribution,
+    PhyloModel,
+    DEFAULT_TREE_VAR_NAME,
+    PhyloModelParseError,
+)
+from treeflow.vi.hmc import (
+    fit_fixed_topology_hmc,
+    KERNEL_HMC,
+    KERNEL_NUTS,
+)
+from treeflow.tree.rooted.tensorflow_rooted_tree import convert_tree_to_tensor
+from treeflow.tree.io import parse_newick, TreeParseError
+from treeflow.evolution.seqio import Alignment, AlignmentParseError
+from treeflow.model.io import write_samples_to_file
+from treeflow.cli.inference_common import (
+    parse_init_values,
+    EXAMPLE_PHYLO_MODEL_DICT,
+    get_tree_vars,
+    write_trees,
+    ALIGNMENT_FORMATS,
+    DEFAULT_ALIGNMENT_FORMAT,
+    InitialValueParseError,
+)
+
+KERNEL_CHOICES = [KERNEL_HMC, KERNEL_NUTS]
+
+
+@click.command()
+@click.option(
+    "-i",
+    "--input",
+    required=True,
+    type=click.Path(exists=True),
+    help="Alignment file",
+)
+@click.option(
+    "-t",
+    "--topology",
+    required=True,
+    type=click.Path(exists=True),
+    help="Topology file",
+)
+@click.option(
+    "-m",
+    "--model-file",
+    type=click.Path(exists=True),
+    help="YAML model definition file",
+)
+@click.option(
+    "-n",
+    "--num-results",
+    required=True,
+    type=int,
+    default=1000,
+    show_default=True,
+    help="Number of MCMC samples to collect after burn-in",
+)
+@click.option(
+    "--num-burnin-steps",
+    required=True,
+    type=int,
+    default=500,
+    show_default=True,
+    help="Number of burn-in steps (discarded)",
+)
+@click.option(
+    "--num-adaptation-steps",
+    required=False,
+    type=int,
+    default=None,
+    help="Steps for dual-averaging step size adaptation (default: num-burnin-steps)",
+)
+@click.option(
+    "--step-size",
+    required=True,
+    type=float,
+    default=0.01,
+    show_default=True,
+    help="Initial leapfrog step size",
+)
+@click.option(
+    "--num-leapfrog-steps",
+    required=True,
+    type=int,
+    default=10,
+    show_default=True,
+    help="Number of leapfrog steps per HMC proposal (ignored for NUTS)",
+)
+@click.option(
+    "--kernel",
+    required=True,
+    type=click.Choice(KERNEL_CHOICES),
+    default=KERNEL_HMC,
+    show_default=True,
+    help="MCMC kernel type",
+)
+@click.option(
+    "--init-values",
+    required=False,
+    type=str,
+    help="Initial values in the format 'scalar_parameter=value1,vector_parameter=value2a|value2b'",
+)
+@click.option("-s", "--seed", required=False, type=int)
+@click.option(
+    "--samples-output",
+    required=False,
+    type=click.Path(),
+    help="Path to save parameter samples in CSV format",
+)
+@click.option(
+    "--tree-samples-output",
+    required=False,
+    type=click.Path(),
+    help="Path to save tree samples in Nexus format",
+)
+@click.option(
+    "--alignment-format",
+    required=True,
+    type=click.Choice(list(ALIGNMENT_FORMATS.keys())),
+    default=DEFAULT_ALIGNMENT_FORMAT,
+    show_default=True,
+    help="File format for alignment",
+)
+@click.option(
+    "--subnewick-format",
+    type=int,
+    required=True,
+    default=0,
+    help="Subnewick format (see `ete3.Tree`)",
+    show_default=True,
+)
+def treeflow_hmc(
+    input,
+    topology,
+    model_file,
+    num_results,
+    num_burnin_steps,
+    num_adaptation_steps,
+    step_size,
+    num_leapfrog_steps,
+    kernel,
+    init_values,
+    seed,
+    samples_output,
+    tree_samples_output,
+    subnewick_format,
+    alignment_format,
+):
+    """
+    Perform fixed-topology Hamiltonian Monte Carlo Bayesian phylogenetic inference
+    with a given tree topology and multiple sequence alignment.
+
+    The tree prior and substitution model used can be specified using the TreeFlow
+    YAML model definition format (see the package documentation).
+    """
+    print(f"Parsing topology {topology}")
+    try:
+        tree = convert_tree_to_tensor(
+            parse_newick(topology, subnewick_format=subnewick_format)
+        )
+    except TreeParseError as ex:
+        raise click.ClickException(str(ex))
+
+    print(f"Parsing alignment {input}")
+    try:
+        alignment = Alignment(
+            input, format=ALIGNMENT_FORMATS[alignment_format]
+        ).get_compressed_alignment()
+    except AlignmentParseError as ex:
+        raise click.ClickException(str(ex))
+    encoded_sequences = alignment.get_encoded_sequence_tensor(tree.taxon_set)
+    pattern_counts = alignment.get_weights_tensor()
+
+    print("Parsing model...")
+    if model_file is None:
+        model_dict = EXAMPLE_PHYLO_MODEL_DICT
+    else:
+        with open(model_file) as f:
+            model_dict = yaml.safe_load(f)
+    try:
+        phylo_model = PhyloModel(model_dict)
+    except PhyloModelParseError as ex:
+        raise click.ClickException(str(ex))
+    model = phylo_model_to_joint_distribution(
+        phylo_model, tree, alignment, pattern_counts=pattern_counts
+    )
+    pinned_model = model.experimental_pin(alignment=encoded_sequences)
+    model_names = set(pinned_model._flat_resolve_names())
+
+    print("Parsing initial values...")
+    try:
+        init_values_dict = (
+            None
+            if init_values is None
+            else {
+                key: tf.constant(value, dtype=DEFAULT_FLOAT_DTYPE_TF)
+                for key, value in parse_init_values(
+                    init_values, model_names=model_names
+                ).items()
+            }
+        )
+    except InitialValueParseError as ex:
+        raise click.ClickException(str(ex))
+
+    if init_values_dict is None:
+        init_state = None
+    else:
+        init_state = {
+            key: value
+            for key, value in init_values_dict.items()
+            if key in model_names
+        }
+        init_state[DEFAULT_TREE_VAR_NAME] = tree
+
+    total_steps = num_results + num_burnin_steps
+    print(
+        f"Running HMC: {num_burnin_steps} burn-in + {num_results} sampling steps "
+        f"({total_steps} total)..."
+    )
+    hmc_res = fit_fixed_topology_hmc(
+        model=pinned_model,
+        topologies={DEFAULT_TREE_VAR_NAME: tree.topology},
+        num_results=num_results,
+        num_burnin_steps=num_burnin_steps,
+        num_adaptation_steps=num_adaptation_steps,
+        step_size=step_size,
+        num_leapfrog_steps=num_leapfrog_steps,
+        kernel=kernel,
+        init_state=init_state,
+        seed=seed,
+    )
+    print("Sampling complete")
+
+    if samples_output is not None or tree_samples_output is not None:
+        constrained_samples = hmc_res.samples
+        names = pinned_model._flat_resolve_names()
+        flat_samples = pinned_model._model_flatten(constrained_samples)
+        samples_dict = dict(zip(names, flat_samples))
+
+        tree_vars = get_tree_vars(phylo_model)
+        tree_samples = {var: samples_dict.pop(var) for var in tree_vars if var in samples_dict}
+
+        if samples_output is not None:
+            print(f"Saving samples to {samples_output}...")
+            write_samples_to_file(
+                constrained_samples,
+                pinned_model,
+                samples_output,
+                vars=samples_dict.keys(),
+                tree_vars={DEFAULT_TREE_VAR_NAME: tree_samples[DEFAULT_TREE_VAR_NAME]}
+                if DEFAULT_TREE_VAR_NAME in tree_samples
+                else None,
+            )
+
+        if tree_samples_output is not None:
+            print(f"Saving tree samples to {tree_samples_output}...")
+            write_trees(tree_samples, topology, tree_samples_output)
+
+    print("Exiting...")

--- a/treeflow/vi/__init__.py
+++ b/treeflow/vi/__init__.py
@@ -1,3 +1,4 @@
 from treeflow.vi.fixed_topology_advi import fit_fixed_topology_variational_approximation
+from treeflow.vi.hmc import fit_fixed_topology_hmc, HMCResults
 from treeflow.vi.marginal_likelihood import *
 from treeflow.vi.optimizers import *

--- a/treeflow/vi/hmc.py
+++ b/treeflow/vi/hmc.py
@@ -1,0 +1,138 @@
+from collections import namedtuple
+from functools import partial
+import typing as tp
+import tensorflow as tf
+import tensorflow_probability as tfp
+from tensorflow_probability.python.distributions import Distribution
+from treeflow import DEFAULT_FLOAT_DTYPE_TF
+from treeflow.tree.topology.tensorflow_tree_topology import TensorflowTreeTopology
+from treeflow.model.event_shape_bijector import (
+    get_fixed_topology_event_shape_and_space_bijector,
+    get_unconstrained_init_values,
+    get_fixed_topology_event_shape,
+)
+
+HMCResults = namedtuple("HMCResults", ("samples", "trace"))
+
+KERNEL_HMC = "hmc"
+KERNEL_NUTS = "nuts"
+
+
+def fit_fixed_topology_hmc(
+    model: Distribution,
+    topologies: tp.Dict[str, TensorflowTreeTopology],
+    num_results: int,
+    num_burnin_steps: int,
+    step_size: float = 0.01,
+    num_leapfrog_steps: int = 10,
+    num_adaptation_steps: tp.Optional[int] = None,
+    init_state: tp.Optional[tp.Dict[str, object]] = None,
+    seed: tp.Optional[int] = None,
+    kernel: str = KERNEL_HMC,
+) -> HMCResults:
+    """Run Hamiltonian Monte Carlo for fixed-topology Bayesian phylogenetic inference.
+
+    Parameters
+    ----------
+    model
+        Pinned joint distribution representing the phylogenetic model.
+    topologies
+        Dict mapping tree variable names to fixed tree topologies.
+    num_results
+        Number of MCMC samples to collect after burn-in.
+    num_burnin_steps
+        Number of burn-in steps (discarded).
+    step_size
+        Initial leapfrog step size.
+    num_leapfrog_steps
+        Number of leapfrog steps per HMC proposal (ignored for NUTS).
+    num_adaptation_steps
+        Number of steps for dual-averaging step size adaptation.
+        Defaults to ``num_burnin_steps``.
+    init_state
+        Optional dict of constrained initial values (same format as ``init_loc``
+        in the VI code).  Unmapped variables start at zero in unconstrained space.
+    seed
+        Optional integer random seed.
+    kernel
+        Kernel type: ``"hmc"`` (default) or ``"nuts"``.
+
+    Returns
+    -------
+    HMCResults
+        Named tuple with ``samples`` (constrained samples as structured output
+        from the model bijector, with batch shape ``[num_results]``) and
+        ``trace`` (raw kernel results from ``sample_chain``).
+    """
+    if num_adaptation_steps is None:
+        num_adaptation_steps = num_burnin_steps
+
+    bijector, base_event_shape = get_fixed_topology_event_shape_and_space_bijector(
+        model, topologies
+    )
+    names = list(base_event_shape.keys())
+
+    def target_log_prob_fn(*unconstrained_parts):
+        unconstrained_dict = dict(zip(names, unconstrained_parts))
+        constrained = bijector.forward(unconstrained_dict)
+        log_prob = model.unnormalized_log_prob(constrained)
+        ldj = bijector.forward_log_det_jacobian(
+            unconstrained_dict,
+            event_ndims={name: 1 for name in names},
+        )
+        return log_prob + ldj
+
+    # Build initial unconstrained state
+    event_shape_fn = partial(
+        get_fixed_topology_event_shape, topology_pins=topologies
+    )
+    init_unconstrained = get_unconstrained_init_values(
+        model,
+        bijector,
+        event_shape_fn=event_shape_fn,
+        init=init_state,
+    )
+    init_parts = [
+        tf.zeros(base_event_shape[n], dtype=DEFAULT_FLOAT_DTYPE_TF)
+        if init_unconstrained[n] is None
+        else tf.cast(init_unconstrained[n], DEFAULT_FLOAT_DTYPE_TF)
+        for n in names
+    ]
+
+    # Build MCMC kernel
+    if kernel == KERNEL_NUTS:
+        inner_kernel = tfp.mcmc.NoUTurnSampler(
+            target_log_prob_fn=target_log_prob_fn,
+            step_size=step_size,
+        )
+    else:
+        inner_kernel = tfp.mcmc.HamiltonianMonteCarlo(
+            target_log_prob_fn=target_log_prob_fn,
+            step_size=step_size,
+            num_leapfrog_steps=num_leapfrog_steps,
+        )
+
+    if num_adaptation_steps > 0:
+        mcmc_kernel = tfp.mcmc.DualAveragingStepSizeAdaptation(
+            inner_kernel=inner_kernel,
+            num_adaptation_steps=num_adaptation_steps,
+        )
+    else:
+        mcmc_kernel = inner_kernel
+
+    samples_unconstrained, trace = tfp.mcmc.sample_chain(
+        num_results=num_results,
+        num_burnin_steps=num_burnin_steps,
+        current_state=init_parts,
+        kernel=mcmc_kernel,
+        seed=seed,
+    )
+
+    # Transform samples back to constrained space
+    samples_dict = dict(zip(names, samples_unconstrained))
+    constrained_samples = bijector.forward(samples_dict)
+
+    return HMCResults(samples=constrained_samples, trace=trace)
+
+
+__all__ = ["fit_fixed_topology_hmc", "HMCResults", "KERNEL_HMC", "KERNEL_NUTS"]


### PR DESCRIPTION
This pull request introduces Hamiltonian Monte Carlo (HMC) inference capabilities to the TreeFlow package, including a new CLI command for running HMC-based Bayesian phylogenetic inference, core implementation of the HMC algorithm, and comprehensive tests for both the CLI and the underlying HMC logic.

The most important changes are:

**New HMC CLI and Integration:**
* Added a new CLI command `treeflow_hmc` for running fixed-topology HMC inference, with support for various options such as model file, kernel choice (HMC or NUTS), initial values, and output file paths. (`treeflow/cli/hmc.py`)
* Registered the new CLI command in the `setup.cfg` entry points for console scripts.

**Core HMC Implementation:**
* Implemented the `fit_fixed_topology_hmc` function and supporting logic for running HMC or NUTS using TensorFlow Probability, including bijector transformations, initial state handling, and kernel selection. Exported `fit_fixed_topology_hmc`, `HMCResults`, `KERNEL_HMC`, and `KERNEL_NUTS` in the module API. (`treeflow/vi/hmc.py`, `treeflow/vi/__init__.py`) [[1]](diffhunk://#diff-c48af810f052f4f17b9a5ffe96a9942d6a17871bf8d03e27ec953ad36a4d16f7R1-R138) [[2]](diffhunk://#diff-06e7efb6de96319bf1fd6d77f16eeb5870dc6e4646c05e3735cc4acde036a6bdR2)

**Testing:**
* Added comprehensive CLI tests for `treeflow_hmc`, covering multiple datasets, model files, kernel choices, and initial value scenarios. (`test/cli/test_hmc_cli.py`)
* Added detailed unit tests for the HMC implementation, verifying sample shapes, finiteness of samples, and correct handling of initial state. (`test/vi/test_hmc.py`)