### PR TITLE
Implement alignment sampling in LeafCTMC

### DIFF
--- a/test/distributions/test_leaf_ctmc.py
+++ b/test/distributions/test_leaf_ctmc.py
@@ -9,14 +9,7 @@ from treeflow.tree.rooted.tensorflow_rooted_tree import (
     TensorflowRootedTree,
     convert_tree_to_tensor,
 )
-from treeflow.tree.topology.tensorflow_tree_topology import (
-    numpy_topology_to_tensor,
-    TensorflowTreeTopology,
-)
-from treeflow.tree.topology.numpy_topology_operations import (
-    get_child_indices,
-    get_preorder_indices,
-)
+from treeflow.tree.topology.tensorflow_tree_topology import numpy_topology_to_tensor
 from treeflow.evolution.substitution.nucleotide.hky import HKY
 from treeflow.distributions.leaf_ctmc import LeafCTMC
 from treeflow.evolution.seqio import Alignment
@@ -205,27 +198,29 @@ def test_leaf_ctmc_discrete_mixture(
 
 
 @pytest.fixture
-def two_taxon_transition_prob_tree():
-    """Minimal 2-taxon tree: leaves 0,1; root 2; branches 0 and 1."""
-    parent_indices = np.array([2, 2], dtype=np.int32)
-    child_indices = get_child_indices(parent_indices)
-    preorder_indices = get_preorder_indices(child_indices)
-    topology = TensorflowTreeTopology(
-        parent_indices=tf.constant(parent_indices),
-        child_indices=tf.constant(child_indices),
-        preorder_indices=tf.constant(preorder_indices),
+def identity_transition_prob_tree(flat_tree_test_data):
+    """3-taxon tree (from flat_tree_test_data) with identity transition matrices."""
+    tree = convert_tree_to_tensor(
+        NumpyRootedTree(
+            node_heights=flat_tree_test_data.node_heights,
+            sampling_times=flat_tree_test_data.sampling_times,
+            parent_indices=flat_tree_test_data.parent_indices,
+        )
+    ).get_unrooted_tree()
+    state_count = 5
+    n_branches = tree.branch_lengths.shape[0]
+    identity_probs = tf.tile(tf.eye(state_count)[tf.newaxis], [n_branches, 1, 1])
+    return TensorflowUnrootedTree(
+        branch_lengths=identity_probs,
+        topology=numpy_topology_to_tensor(tree.topology),
     )
-    state_count = 4
-    # Uniform transition probs
-    transition_probs = tf.fill([2, state_count, state_count], 1.0 / state_count)
-    return TensorflowUnrootedTree(branch_lengths=transition_probs, topology=topology)
 
 
-def test_LeafCTMC_sample_shape(two_taxon_transition_prob_tree):
-    state_count = two_taxon_transition_prob_tree.branch_lengths.shape[-1]
-    taxon_count = two_taxon_transition_prob_tree.taxon_count
-    frequencies = tf.fill([state_count], 0.25)
-    dist = LeafCTMC(two_taxon_transition_prob_tree, frequencies)
+def test_LeafCTMC_sample_shape(transition_prob_tree, hky_params):
+    state_count = transition_prob_tree.branch_lengths.shape[-1]
+    taxon_count = transition_prob_tree.taxon_count
+    frequencies = tf.fill([state_count], 1.0 / state_count)
+    dist = LeafCTMC(transition_prob_tree, frequencies)
 
     n = 7
     samples = dist.sample(n, seed=(0, 1))
@@ -238,41 +233,36 @@ def test_LeafCTMC_sample_shape(two_taxon_transition_prob_tree):
     assert tf.reduce_all((samples == 0) | (samples == 1)).numpy()
 
 
-def test_LeafCTMC_sample_identity_transition(two_taxon_transition_prob_tree):
+def test_LeafCTMC_sample_identity_transition(identity_transition_prob_tree):
     """With identity transition matrices, all leaves must have the same state as root."""
-    state_count = two_taxon_transition_prob_tree.branch_lengths.shape[-1]
-    topology = two_taxon_transition_prob_tree.topology
-    # Identity transition: child always equals parent
-    identity_probs = tf.eye(state_count)[tf.newaxis, :, :]  # [1, state, state]
-    identity_probs = tf.tile(identity_probs, [2, 1, 1])  # [2, state, state]
-    transition_probs_tree = TensorflowUnrootedTree(
-        branch_lengths=identity_probs, topology=topology
-    )
-    frequencies = tf.constant([1.0, 0.0, 0.0, 0.0])  # always sample state 0 at root
-    dist = LeafCTMC(transition_probs_tree, frequencies)
+    state_count = identity_transition_prob_tree.branch_lengths.shape[-1]
+    # Force root to always be state 0
+    frequencies = tf.one_hot(0, state_count)
+    dist = LeafCTMC(identity_transition_prob_tree, frequencies)
 
-    samples = dist.sample(10, seed=(0, 1))  # [10, 2, 4]
-    # With freq=[1,0,0,0] and identity transitions, all leaves must be state 0
-    assert tf.reduce_all(samples[..., 0] == 1).numpy()  # one-hot position 0 always 1
+    n = 10
+    samples = dist.sample(n, seed=(0, 1))  # [10, 3, state_count]
+    # All leaves must be state 0 (one-hot position 0 is 1)
+    assert tf.reduce_all(samples[..., 0] == 1).numpy()
 
 
-def test_LeafCTMC_sample_seed_reproducibility(two_taxon_transition_prob_tree):
-    state_count = two_taxon_transition_prob_tree.branch_lengths.shape[-1]
-    frequencies = tf.fill([state_count], 0.25)
-    dist = LeafCTMC(two_taxon_transition_prob_tree, frequencies)
+def test_LeafCTMC_sample_seed_reproducibility(transition_prob_tree):
+    state_count = transition_prob_tree.branch_lengths.shape[-1]
+    frequencies = tf.fill([state_count], 1.0 / state_count)
+    dist = LeafCTMC(transition_prob_tree, frequencies)
 
     s1 = dist.sample(5, seed=(42, 0))
     s2 = dist.sample(5, seed=(42, 0))
     assert tf.reduce_all(s1 == s2).numpy()
 
 
-def test_LeafCTMC_sample_prob_positive(two_taxon_transition_prob_tree):
+def test_LeafCTMC_sample_prob_positive(transition_prob_tree):
     """Samples must lie in the support: prob should be positive and finite."""
-    state_count = two_taxon_transition_prob_tree.branch_lengths.shape[-1]
-    frequencies = tf.fill([state_count], 0.25)
-    dist = LeafCTMC(two_taxon_transition_prob_tree, frequencies)
+    state_count = transition_prob_tree.branch_lengths.shape[-1]
+    frequencies = tf.fill([state_count], 1.0 / state_count)
+    dist = LeafCTMC(transition_prob_tree, frequencies)
 
-    sample = dist.sample(seed=(0, 1))  # [2, 4] int32 one-hot
+    sample = dist.sample(seed=(0, 1))  # [taxon_count, state_count] int32 one-hot
     # _prob expects float one-hot; cast to match what the likelihood function uses
     p = dist.prob(tf.cast(sample, tf.float32))
     assert tf.math.is_finite(p).numpy()
@@ -280,10 +270,10 @@ def test_LeafCTMC_sample_prob_positive(two_taxon_transition_prob_tree):
 
 
 @pytest.mark.parametrize("function_mode", [True, False])
-def test_LeafCTMC_sample_tf_function(two_taxon_transition_prob_tree, function_mode):
-    state_count = two_taxon_transition_prob_tree.branch_lengths.shape[-1]
-    frequencies = tf.fill([state_count], 0.25)
-    dist = LeafCTMC(two_taxon_transition_prob_tree, frequencies)
+def test_LeafCTMC_sample_tf_function(transition_prob_tree, function_mode):
+    state_count = transition_prob_tree.branch_lengths.shape[-1]
+    frequencies = tf.fill([state_count], 1.0 / state_count)
+    dist = LeafCTMC(transition_prob_tree, frequencies)
 
     def sample_fn():
         return dist.sample(3, seed=(0, 1))
@@ -292,4 +282,4 @@ def test_LeafCTMC_sample_tf_function(two_taxon_transition_prob_tree, function_mo
         sample_fn = tf.function(sample_fn)
 
     result = sample_fn()
-    assert result.shape == (3, two_taxon_transition_prob_tree.taxon_count, state_count)
+    assert result.shape == (3, transition_prob_tree.taxon_count, state_count)

--- a/test/distributions/test_leaf_ctmc.py
+++ b/test/distributions/test_leaf_ctmc.py
@@ -226,7 +226,7 @@ def test_LeafCTMC_sample_shape(transition_prob_tree, hky_params):
     samples = dist.sample(n, seed=(0, 1))
 
     assert samples.shape == (n, taxon_count, state_count)
-    assert samples.dtype == tf.int32
+    assert samples.dtype == frequencies.dtype
     # Each row must be a valid one-hot vector
     row_sums = tf.reduce_sum(samples, axis=-1)
     assert tf.reduce_all(row_sums == 1).numpy()
@@ -262,9 +262,8 @@ def test_LeafCTMC_sample_prob_positive(transition_prob_tree):
     frequencies = tf.fill([state_count], 1.0 / state_count)
     dist = LeafCTMC(transition_prob_tree, frequencies)
 
-    sample = dist.sample(seed=(0, 1))  # [taxon_count, state_count] int32 one-hot
-    # _prob expects float one-hot; cast to match what the likelihood function uses
-    p = dist.prob(tf.cast(sample, tf.float32))
+    sample = dist.sample(seed=(0, 1))  # [taxon_count, state_count] float one-hot
+    p = dist.prob(sample)
     assert tf.math.is_finite(p).numpy()
     assert p.numpy() > 0.0
 

--- a/test/distributions/test_leaf_ctmc.py
+++ b/test/distributions/test_leaf_ctmc.py
@@ -9,7 +9,14 @@ from treeflow.tree.rooted.tensorflow_rooted_tree import (
     TensorflowRootedTree,
     convert_tree_to_tensor,
 )
-from treeflow.tree.topology.tensorflow_tree_topology import numpy_topology_to_tensor
+from treeflow.tree.topology.tensorflow_tree_topology import (
+    numpy_topology_to_tensor,
+    TensorflowTreeTopology,
+)
+from treeflow.tree.topology.numpy_topology_operations import (
+    get_child_indices,
+    get_preorder_indices,
+)
 from treeflow.evolution.substitution.nucleotide.hky import HKY
 from treeflow.distributions.leaf_ctmc import LeafCTMC
 from treeflow.evolution.seqio import Alignment
@@ -190,3 +197,99 @@ def test_leaf_ctmc_discrete_mixture(
     )
 
     assert_allclose(res.numpy(), expected)
+
+
+# ---------------------------------------------------------------------------
+# Sampling tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def two_taxon_transition_prob_tree():
+    """Minimal 2-taxon tree: leaves 0,1; root 2; branches 0 and 1."""
+    parent_indices = np.array([2, 2], dtype=np.int32)
+    child_indices = get_child_indices(parent_indices)
+    preorder_indices = get_preorder_indices(child_indices)
+    topology = TensorflowTreeTopology(
+        parent_indices=tf.constant(parent_indices),
+        child_indices=tf.constant(child_indices),
+        preorder_indices=tf.constant(preorder_indices),
+    )
+    state_count = 4
+    # Uniform transition probs
+    transition_probs = tf.fill([2, state_count, state_count], 1.0 / state_count)
+    return TensorflowUnrootedTree(branch_lengths=transition_probs, topology=topology)
+
+
+def test_LeafCTMC_sample_shape(two_taxon_transition_prob_tree):
+    state_count = two_taxon_transition_prob_tree.branch_lengths.shape[-1]
+    taxon_count = two_taxon_transition_prob_tree.taxon_count
+    frequencies = tf.fill([state_count], 0.25)
+    dist = LeafCTMC(two_taxon_transition_prob_tree, frequencies)
+
+    n = 7
+    samples = dist.sample(n, seed=(0, 1))
+
+    assert samples.shape == (n, taxon_count, state_count)
+    assert samples.dtype == tf.int32
+    # Each row must be a valid one-hot vector
+    row_sums = tf.reduce_sum(samples, axis=-1)
+    assert tf.reduce_all(row_sums == 1).numpy()
+    assert tf.reduce_all((samples == 0) | (samples == 1)).numpy()
+
+
+def test_LeafCTMC_sample_identity_transition(two_taxon_transition_prob_tree):
+    """With identity transition matrices, all leaves must have the same state as root."""
+    state_count = two_taxon_transition_prob_tree.branch_lengths.shape[-1]
+    topology = two_taxon_transition_prob_tree.topology
+    # Identity transition: child always equals parent
+    identity_probs = tf.eye(state_count)[tf.newaxis, :, :]  # [1, state, state]
+    identity_probs = tf.tile(identity_probs, [2, 1, 1])  # [2, state, state]
+    transition_probs_tree = TensorflowUnrootedTree(
+        branch_lengths=identity_probs, topology=topology
+    )
+    frequencies = tf.constant([1.0, 0.0, 0.0, 0.0])  # always sample state 0 at root
+    dist = LeafCTMC(transition_probs_tree, frequencies)
+
+    samples = dist.sample(10, seed=(0, 1))  # [10, 2, 4]
+    # With freq=[1,0,0,0] and identity transitions, all leaves must be state 0
+    assert tf.reduce_all(samples[..., 0] == 1).numpy()  # one-hot position 0 always 1
+
+
+def test_LeafCTMC_sample_seed_reproducibility(two_taxon_transition_prob_tree):
+    state_count = two_taxon_transition_prob_tree.branch_lengths.shape[-1]
+    frequencies = tf.fill([state_count], 0.25)
+    dist = LeafCTMC(two_taxon_transition_prob_tree, frequencies)
+
+    s1 = dist.sample(5, seed=(42, 0))
+    s2 = dist.sample(5, seed=(42, 0))
+    assert tf.reduce_all(s1 == s2).numpy()
+
+
+def test_LeafCTMC_sample_prob_positive(two_taxon_transition_prob_tree):
+    """Samples must lie in the support: prob should be positive and finite."""
+    state_count = two_taxon_transition_prob_tree.branch_lengths.shape[-1]
+    frequencies = tf.fill([state_count], 0.25)
+    dist = LeafCTMC(two_taxon_transition_prob_tree, frequencies)
+
+    sample = dist.sample(seed=(0, 1))  # [2, 4] int32 one-hot
+    # _prob expects float one-hot; cast to match what the likelihood function uses
+    p = dist.prob(tf.cast(sample, tf.float32))
+    assert tf.math.is_finite(p).numpy()
+    assert p.numpy() > 0.0
+
+
+@pytest.mark.parametrize("function_mode", [True, False])
+def test_LeafCTMC_sample_tf_function(two_taxon_transition_prob_tree, function_mode):
+    state_count = two_taxon_transition_prob_tree.branch_lengths.shape[-1]
+    frequencies = tf.fill([state_count], 0.25)
+    dist = LeafCTMC(two_taxon_transition_prob_tree, frequencies)
+
+    def sample_fn():
+        return dist.sample(3, seed=(0, 1))
+
+    if function_mode:
+        sample_fn = tf.function(sample_fn)
+
+    result = sample_fn()
+    assert result.shape == (3, two_taxon_transition_prob_tree.taxon_count, state_count)

--- a/treeflow/distributions/leaf_ctmc.py
+++ b/treeflow/distributions/leaf_ctmc.py
@@ -1,5 +1,4 @@
 import typing as tp
-import warnings
 import tensorflow as tf
 from tensorflow_probability.python.internal import prefer_static as ps
 from tensorflow_probability.python.util import ParameterProperties
@@ -10,6 +9,7 @@ from tensorflow_probability.python.distributions import (
     Distribution,
 )
 from treeflow.traversal.phylo_likelihood import phylogenetic_likelihood
+from treeflow.traversal.sample_ctmc import sample_ctmc_preorder
 
 
 class LeafCTMC(Distribution):
@@ -59,11 +59,23 @@ class LeafCTMC(Distribution):
         )
 
     def _sample_n(self, n, seed=None):
-        warnings.warn("Dummy sampling of alignment")
-        sample_shape = tf.concat(
-            [[n], self.batch_shape_tensor(), self.event_shape_tensor()], axis=0
+        if self.transition_probs_tree.topology.has_batch_dimensions():
+            raise NotImplementedError("Topology batching not yet supported")
+        batch_shape = self.batch_shape_tensor()
+        transition_probs = self._broadcast_transition_probs(
+            tf.concat([[n], batch_shape], axis=0)
         )
-        return tf.zeros(sample_shape, dtype=tf.int32)
+        topology = self.transition_probs_tree.topology
+        return sample_ctmc_preorder(
+            transition_probs=transition_probs,
+            frequencies=self.frequencies,
+            preorder_indices=topology.preorder_indices,
+            parent_indices=topology.parent_indices,
+            taxon_count=topology.taxon_count,
+            n=n,
+            batch_shape=batch_shape,
+            seed=seed,
+        )
 
     def _broadcast_transition_probs(self, sample_and_batch_shape) -> tf.Tensor:
         transition_probs_shape = ps.shape(self.transition_probs_tree.branch_lengths)

--- a/treeflow/distributions/leaf_ctmc.py
+++ b/treeflow/distributions/leaf_ctmc.py
@@ -26,7 +26,7 @@ class LeafCTMC(Distribution):
             validate_args=validate_args,
             allow_nan_stats=allow_nan_stats,
             name=name,
-            dtype=tf.int32,
+            dtype=frequencies.dtype,
             reparameterization_type=NOT_REPARAMETERIZED,
             parameters=parameters,
         )

--- a/treeflow/traversal/sample_ctmc.py
+++ b/treeflow/traversal/sample_ctmc.py
@@ -1,0 +1,133 @@
+import tensorflow as tf
+from tensorflow_probability.python.internal import samplers
+
+
+@tf.function
+def sample_ctmc_preorder(
+    transition_probs: tf.Tensor,
+    frequencies: tf.Tensor,
+    preorder_indices: tf.Tensor,
+    parent_indices: tf.Tensor,
+    taxon_count: tf.Tensor,
+    n: tf.Tensor,
+    batch_shape: tf.Tensor,
+    seed=None,
+) -> tf.Tensor:
+    """
+    Sample leaf sequences from a phylogenetic CTMC via preorder traversal.
+
+    Parameters
+    ----------
+    transition_probs
+        Shape [...batch, n_branches, state, state].
+        transition_probs[..., i, s, t] = P(child state = t | parent state = s) on branch i.
+        Branch index i corresponds to node i (for all non-root nodes).
+    frequencies
+        Shape [...batch, state]. Equilibrium frequencies used to sample the root state.
+    preorder_indices
+        Shape [2n-1]. All node indices in preorder order (root first).
+    parent_indices
+        Shape [2n-2]. parent_indices[i] is the parent node index of node i.
+    taxon_count
+        Number of leaf taxa (n).
+    n
+        Number of independent samples to draw.
+    batch_shape
+        Batch shape as a 1-D tensor.
+    seed
+        Optional seed for stateless random ops.
+
+    Returns
+    -------
+    tf.Tensor
+        Shape [n, ...batch, taxon_count, state_count]. One-hot encoded leaf sequences
+        as tf.int32.
+    """
+    node_count = 2 * taxon_count - 1
+    state_count = tf.shape(frequencies)[-1]
+    sample_and_batch_shape = tf.concat([[n], batch_shape], axis=0)
+    flat_size = tf.reduce_prod(sample_and_batch_shape)
+
+    # Split seed: one per node (root + 2n-2 non-root nodes = 2n-1 total)
+    all_seeds = samplers.split_seed(seed, n=node_count)
+
+    # ------------------------------------------------------------------ #
+    # Root sampling                                                        #
+    # ------------------------------------------------------------------ #
+    # Broadcast frequencies to [n, ...batch, state] then flatten to [N, state]
+    freq_b = tf.broadcast_to(
+        frequencies,
+        tf.concat([sample_and_batch_shape, [state_count]], axis=0),
+    )
+    freq_flat = tf.reshape(freq_b, [flat_size, state_count])  # [N, state]
+    root_state_flat = tf.cast(
+        tf.random.stateless_categorical(tf.math.log(freq_flat), 1, seed=all_seeds[0])[
+            :, 0
+        ],
+        tf.int32,
+    )  # [N]
+    root_state = tf.reshape(root_state_flat, sample_and_batch_shape)  # [n, ...batch]
+
+    # ------------------------------------------------------------------ #
+    # TensorArray: one entry per node, each holding [n, ...batch] states  #
+    # ------------------------------------------------------------------ #
+    states_ta = tf.TensorArray(
+        dtype=tf.int32,
+        size=node_count,
+        clear_after_read=False,
+        element_shape=None,
+    )
+    root_index = node_count - 1
+    states_ta = states_ta.write(root_index, root_state)
+
+    # ------------------------------------------------------------------ #
+    # Preorder traversal: skip root (index 0 in preorder_indices)         #
+    # ------------------------------------------------------------------ #
+    for step in tf.range(1, node_count):
+        node = preorder_indices[step]
+        parent = parent_indices[node]
+        parent_state = states_ta.read(parent)  # [n, ...batch]
+
+        # Branch transition probs for this node: [...batch, state, state]
+        branch_probs = tf.gather(transition_probs, node, axis=-3)
+
+        # Broadcast to [n, ...batch, state, state] then flatten to [N, state, state]
+        branch_probs_b = tf.broadcast_to(
+            branch_probs,
+            tf.concat([sample_and_batch_shape, [state_count, state_count]], axis=0),
+        )
+        branch_probs_flat = tf.reshape(
+            branch_probs_b, [flat_size, state_count, state_count]
+        )  # [N, state, state]
+
+        # Select row for parent state: child_probs[i] = branch_probs_flat[i, parent_state_flat[i], :]
+        parent_state_flat = tf.reshape(parent_state, [flat_size])  # [N]
+        child_probs_flat = tf.gather(
+            branch_probs_flat, parent_state_flat, axis=1, batch_dims=1
+        )  # [N, state]
+
+        child_state_flat = tf.cast(
+            tf.random.stateless_categorical(
+                tf.math.log(child_probs_flat), 1, seed=all_seeds[step]
+            )[:, 0],
+            tf.int32,
+        )  # [N]
+        child_state = tf.reshape(child_state_flat, sample_and_batch_shape)
+
+        states_ta = states_ta.write(node, child_state)
+
+    # ------------------------------------------------------------------ #
+    # Collect leaf states and one-hot encode                              #
+    # ------------------------------------------------------------------ #
+    # states_ta.gather gives [taxon_count, n, ...batch]
+    leaf_states = states_ta.gather(tf.range(taxon_count))
+
+    # Transpose to [n, ...batch, taxon_count]
+    n_dims = tf.size(sample_and_batch_shape)
+    perm = tf.concat([tf.range(1, n_dims + 1), [0]], axis=0)
+    leaf_states = tf.transpose(leaf_states, perm)
+
+    return tf.one_hot(leaf_states, state_count, dtype=tf.int32)
+
+
+__all__ = ["sample_ctmc_preorder"]

--- a/treeflow/traversal/sample_ctmc.py
+++ b/treeflow/traversal/sample_ctmc.py
@@ -127,7 +127,7 @@ def sample_ctmc_preorder(
     perm = tf.concat([tf.range(1, n_dims + 1), [0]], axis=0)
     leaf_states = tf.transpose(leaf_states, perm)
 
-    return tf.one_hot(leaf_states, state_count, dtype=tf.int32)
+    return tf.one_hot(leaf_states, state_count, dtype=frequencies.dtype)
 
 
 __all__ = ["sample_ctmc_preorder"]


### PR DESCRIPTION
## Summary

- Adds `treeflow/traversal/sample_ctmc.py` with `sample_ctmc_preorder()`: a preorder traversal that samples root state from equilibrium frequencies, then propagates states root→leaves via the branch transition matrices using `tf.random.stateless_categorical`
- Replaces the dummy `_sample_n` in `LeafCTMC` (which returned zeros with a warning) with a real implementation calling the new traversal function
- Adds 6 sampling tests to `test/distributions/test_leaf_ctmc.py` covering shape/dtype, deterministic identity-transition case, seed reproducibility, positive probability, and `tf.function` compatibility — all using ≥3-taxon trees from existing fixtures

## Test plan

- [ ] `pytest test/distributions/test_leaf_ctmc.py -v` — all 21 tests pass (15 existing + 6 new)
- [ ] `test_LeafCTMC_sample_identity_transition`: with identity P matrices and root pinned to state 0, all 3 leaves must sample state 0
- [ ] `test_LeafCTMC_sample_seed_reproducibility`: same seed produces identical samples

🤖 Generated with [Claude Code](https://claude.com/claude-code)