### PR TITLE
Add discrete-trait (DTA) model and treeflow_dta_hmc CLI

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -6,3 +6,5 @@ Command line interfaces
 
    cli.treeflow_vi
    cli.treeflow_ml
+   cli.treeflow_hmc
+   cli.treeflow_dta_hmc

--- a/docs/source/cli.treeflow_dta_hmc.rst
+++ b/docs/source/cli.treeflow_dta_hmc.rst
@@ -1,0 +1,77 @@
+Discrete-trait HMC CLI
+=======================
+
+``treeflow_dta_hmc`` runs fixed-topology Hamiltonian Monte Carlo (or NUTS) on a
+discrete-trait evolutionary model (e.g. Bayesian phylogeography of
+:cite:`lemey2009bayesian`-style migration-rate estimation) given a fixed
+time-tree and a two-column CSV of tip trait labels.
+
+Inputs
+------
+
+* ``-t / --topology`` — Newick tree file, branch lengths in time units.
+* ``-r / --traits`` — CSV with columns ``taxon,trait`` (column names are
+  configurable via ``--taxon-column`` and ``--trait-column``). Unknown states
+  can be marked with ``?``, ``-``, ``NA``, ``N/A``, or an empty string and
+  are treated as missing (flat partials).
+* ``-m / --model-file`` — YAML model file declaring priors on the
+  exchangeability rates and equilibrium frequencies. See
+  :doc:`model-definition` for the ``discrete_trait`` block format.
+
+Minimal YAML model
+------------------
+
+.. code-block:: yaml
+
+    tree: fixed
+    clock:
+      strict:
+        clock_rate: 0.5           # mean migration-rate scalar
+    substitution:
+      discrete_trait:
+        n_states: 5               # K states
+        frequencies:
+          dirichlet:
+            concentration: [1.0, 1.0, 1.0, 1.0, 1.0]
+        rates:                    # K*(K-1)/2 = 10 exchangeability rates
+          dirichlet:
+            concentration: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    site: none
+
+Minimal traits CSV
+------------------
+
+.. code-block:: text
+
+    taxon,trait
+    seq1,NY
+    seq2,HK
+    seq3,NZ
+    seq4,NY
+
+Example invocation
+------------------
+
+.. code-block:: bash
+
+    treeflow_dta_hmc \
+      -t tree.nwk \
+      -r traits.csv \
+      -m model.yaml \
+      -n 1000 \
+      --num-burnin-steps 500 \
+      --kernel nuts \
+      --samples-output posterior.csv
+
+Outputs
+-------
+
+* ``--samples-output`` — CSV of posterior samples for ``frequencies``,
+  ``rates``, and any other free parameters declared in the YAML model file.
+
+Full CLI reference
+------------------
+
+.. click:: treeflow.cli.dta_hmc:treeflow_dta_hmc
+   :prog: treeflow_dta_hmc
+   :nested: full

--- a/docs/source/cli.treeflow_hmc.rst
+++ b/docs/source/cli.treeflow_hmc.rst
@@ -1,0 +1,10 @@
+HMC CLI
+=========
+
+``treeflow_hmc`` runs fixed-topology Hamiltonian Monte Carlo (or NUTS)
+Bayesian phylogenetic inference given a multiple sequence alignment and a
+fixed tree topology.
+
+.. click:: treeflow.cli.hmc:treeflow_hmc
+   :prog: treeflow_hmc
+   :nested: full

--- a/docs/source/model-definition.md
+++ b/docs/source/model-definition.md
@@ -46,3 +46,48 @@ For parameters, see the corresponding TensorFlow Probability distribution.
 * `exponential`
 * `beta`
 * `dirichlet`
+
+## Discrete-trait substitution model
+
+For fixed-tree discrete-trait analyses (e.g. Bayesian phylogeography and
+migration-rate estimation), TreeFlow provides a K-state time-reversible
+substitution model following [Lemey et al. (2009)](https://doi.org/10.1371/journal.pcbi.1000520).
+Use the `discrete_trait` substitution block together with the
+[`treeflow_dta_hmc`](cli.treeflow_dta_hmc) CLI.
+
+The block requires:
+
+* `n_states`: the integer number of discrete states K.
+* `frequencies`: a `K`-vector of equilibrium state frequencies (typically a
+  Dirichlet prior on the `K`-simplex).
+* `rates`: the `K*(K-1)/2` symmetric exchangeability rates in row-major
+  upper-triangular order: `(0,1), (0,2), ..., (0,K-1), (1,2), ...`. For
+  reversible models the rate matrix is normalised so that its trace equals
+  one, so only the *relative* rates are identifiable; the overall migration
+  rate scale is absorbed into `clock.strict.clock_rate`.
+
+Example for K = 5 states:
+
+```yaml
+tree: fixed
+clock:
+  strict:
+    clock_rate:
+      lognormal:
+        loc: 0.0
+        scale: 1.0
+substitution:
+  discrete_trait:
+    n_states: 5
+    frequencies:
+      dirichlet:
+        concentration: [1.0, 1.0, 1.0, 1.0, 1.0]
+    rates:
+      dirichlet:
+        concentration: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+site: none
+```
+
+The tip data format for this model is a two-column CSV of `(taxon, trait)`
+labels rather than a sequence alignment; see
+[`treeflow_dta_hmc`](cli.treeflow_dta_hmc) for the CLI that consumes it.

--- a/docs/source/treeflow.cli.dta_hmc.rst
+++ b/docs/source/treeflow.cli.dta_hmc.rst
@@ -1,0 +1,7 @@
+treeflow.cli.dta_hmc module
+============================
+
+.. automodule:: treeflow.cli.dta_hmc
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/treeflow.cli.hmc.rst
+++ b/docs/source/treeflow.cli.hmc.rst
@@ -1,0 +1,7 @@
+treeflow.cli.hmc module
+========================
+
+.. automodule:: treeflow.cli.hmc
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/treeflow.cli.rst
+++ b/docs/source/treeflow.cli.rst
@@ -13,6 +13,8 @@ Submodules
    :maxdepth: 1
 
    treeflow.cli.benchmark
+   treeflow.cli.dta_hmc
+   treeflow.cli.hmc
    treeflow.cli.inference_common
    treeflow.cli.ml
    treeflow.cli.vi

--- a/docs/source/treeflow.evolution.rst
+++ b/docs/source/treeflow.evolution.rst
@@ -22,3 +22,4 @@ Submodules
    :maxdepth: 1
 
    treeflow.evolution.seqio
+   treeflow.evolution.traitio

--- a/docs/source/treeflow.evolution.substitution.discrete_trait.dta.rst
+++ b/docs/source/treeflow.evolution.substitution.discrete_trait.dta.rst
@@ -1,0 +1,7 @@
+treeflow.evolution.substitution.discrete_trait.dta module
+==========================================================
+
+.. automodule:: treeflow.evolution.substitution.discrete_trait.dta
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/treeflow.evolution.substitution.discrete_trait.rst
+++ b/docs/source/treeflow.evolution.substitution.discrete_trait.rst
@@ -1,0 +1,15 @@
+treeflow.evolution.substitution.discrete_trait package
+=======================================================
+
+.. automodule:: treeflow.evolution.substitution.discrete_trait
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 1
+
+   treeflow.evolution.substitution.discrete_trait.dta

--- a/docs/source/treeflow.evolution.substitution.rst
+++ b/docs/source/treeflow.evolution.substitution.rst
@@ -12,6 +12,7 @@ Subpackages
 .. toctree::
    :maxdepth: 1
 
+   treeflow.evolution.substitution.discrete_trait
    treeflow.evolution.substitution.nucleotide
 
 Submodules

--- a/docs/source/treeflow.evolution.traitio.rst
+++ b/docs/source/treeflow.evolution.traitio.rst
@@ -1,0 +1,7 @@
+treeflow.evolution.traitio module
+==================================
+
+.. automodule:: treeflow.evolution.traitio
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/examples/dta-validation/.gitignore
+++ b/examples/dta-validation/.gitignore
@@ -1,0 +1,8 @@
+dta-validation_D.nexus
+dta-validation_psi.trees
+traits.csv
+tree.nwk
+samples.csv
+samples-smoke.csv
+run.log
+smoke.log

--- a/examples/dta-validation/README.md
+++ b/examples/dta-validation/README.md
@@ -1,0 +1,45 @@
+# DTA recovery validation for `treeflow_dta_hmc`
+
+End-to-end sanity check for the discrete-trait (phylogeography / DTA)
+NUTS CLI added in this branch: simulate a K-state trait under a known
+Q on a known tree, fit with `treeflow_dta_hmc`, and verify that the
+posterior mean / 95% CI cover the simulation truth.
+
+## Truth (see `dta-validation.lphy`)
+
+- `K = 4` states, labelled `"0","1","2","3"` (lexicographic order)
+- `π = [0.4, 0.3, 0.2, 0.1]`
+- `R = [0.25, 0.15, 0.10, 0.20, 0.10, 0.20]`  (row-major upper triangle)
+- `μ = 0.2`
+- `N = 400` tips, Yule(λ=1)
+
+## Requirements
+
+- [LinguaPhylo](https://github.com/LinguaPhylo/linguaPhylo) built
+  locally for simulation — default path
+  `~/Git/linguaPhylo/lphy-studio/target/lphy-studio-1.7.0`
+- `treeflow_dta_hmc` on `$PATH` (installed with this repo's extras)
+
+## Run
+
+```sh
+./run.sh
+```
+
+Runs: `slphy` → `convert.py` (nexus → `traits.csv` + `tree.nwk`) →
+`treeflow_dta_hmc` (500 burn-in + 1000 samples, default NUTS) →
+`summarize.py` (posterior vs. truth).
+
+On a MacBook this takes ≈ 51 min (NUTS is the bottleneck, the first
+~10 s is LPhy).
+
+## Expected outcome
+
+Posterior covers 9/10 parameters on the default seed. The one miss
+(π₁) is a finite-tree-depth artefact — observed state-1 count is
+well below the stationary expectation.
+
+For reference, the Stan port at
+[`phylogeo-stan`](https://github.com/alexeid/phylogeo-stan) runs the
+same model on the same dataset in ≈ 97 s (32× faster) with the same
+9/10 coverage.

--- a/examples/dta-validation/convert.py
+++ b/examples/dta-validation/convert.py
@@ -1,0 +1,72 @@
+"""Convert LPhy nexus outputs to treeflow_dta_hmc inputs.
+
+Reads:
+  dta-validation_D.nexus      -- single-site 'standard' alignment
+  dta-validation_psi.trees    -- nexus trees block (one tree)
+
+Writes:
+  traits.csv                  -- taxon,trait (header), one row per tip
+  tree.nwk                    -- a single newick line
+"""
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+def parse_nexus_alignment(path: Path) -> dict[str, str]:
+    text = path.read_text()
+    m = re.search(r"matrix\s*(.*?)\s*;", text, re.DOTALL | re.IGNORECASE)
+    if not m:
+        raise ValueError(f"No matrix block in {path}")
+    mapping: dict[str, str] = {}
+    for line in m.group(1).strip().splitlines():
+        parts = line.strip().split()
+        if len(parts) < 2:
+            continue
+        taxon, state = parts[0], parts[1]
+        mapping[taxon] = state
+    return mapping
+
+
+def parse_nexus_tree(path: Path) -> str:
+    text = path.read_text()
+    m = re.search(
+        r"^\s*tree\s+\S+\s*=\s*(?:\[[^\]]*\]\s*)?(.+?;)\s*$",
+        text,
+        re.MULTILINE | re.IGNORECASE,
+    )
+    if not m:
+        raise ValueError(f"No tree statement found in {path}")
+    return m.group(1).strip()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--indir", type=Path, default=Path(__file__).parent)
+    ap.add_argument("--prefix", default="dta-validation")
+    args = ap.parse_args()
+
+    traits = parse_nexus_alignment(args.indir / f"{args.prefix}_D.nexus")
+    newick = parse_nexus_tree(args.indir / f"{args.prefix}_psi.trees")
+
+    traits_path = args.indir / "traits.csv"
+    with traits_path.open("w") as fh:
+        fh.write("taxon,trait\n")
+        for taxon in sorted(traits, key=lambda s: int(s) if s.isdigit() else s):
+            fh.write(f"{taxon},{traits[taxon]}\n")
+
+    tree_path = args.indir / "tree.nwk"
+    tree_path.write_text(newick + "\n")
+
+    counts: dict[str, int] = {}
+    for v in traits.values():
+        counts[v] = counts.get(v, 0) + 1
+    print(f"Wrote {traits_path} ({len(traits)} taxa)")
+    print(f"Wrote {tree_path}")
+    print(f"State counts: {sorted(counts.items())}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dta-validation/dta-validation.lphy
+++ b/examples/dta-validation/dta-validation.lphy
@@ -1,0 +1,24 @@
+// DTA recovery experiment: simulate a K=4 discrete trait on a Yule tree
+// under a known time-reversible Q, then check whether treeflow_dta_hmc
+// recovers π and R when given the true tree.
+
+data {
+  K = 4;
+  N = 400;
+}
+
+model {
+  // --- Simulation truth (fixed, not sampled) ---
+  π = [0.4, 0.3, 0.2, 0.1];
+  R = [0.25, 0.15, 0.10, 0.20, 0.10, 0.20];  // dim = K(K-1)/2 = 6
+  Q = generalTimeReversible(freq=π, rates=R);
+
+  // Yule tree: λ=1 → total tree length ≈ N-1 ≈ 399, root height ≈ log(N) ≈ 6
+  ψ ~ Yule(lambda=1.0, n=N);
+
+  // μ=0.2 → ~1.2 per root-to-tip, ~80 total events; better state mixing
+  // without saturation (first run at μ=0.1 gave only 2/400 tips in state 3)
+  μ = 0.2;
+
+  D ~ PhyloCTMC(L=1, Q=Q, mu=μ, tree=ψ, dataType=standard(K));
+}

--- a/examples/dta-validation/model.yaml
+++ b/examples/dta-validation/model.yaml
@@ -1,0 +1,14 @@
+tree: fixed
+clock:
+  strict:
+    clock_rate: 0.2
+substitution:
+  discrete_trait:
+    n_states: 4
+    frequencies:
+      dirichlet:
+        concentration: [1.0, 1.0, 1.0, 1.0]
+    rates:
+      dirichlet:
+        concentration: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+site: none

--- a/examples/dta-validation/run.sh
+++ b/examples/dta-validation/run.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# End-to-end DTA recovery experiment: LPhy simulate -> treeflow_dta_hmc.
+#
+# Truth (see dta-validation.lphy):
+#   K = 4 states
+#   pi = [0.4, 0.3, 0.2, 0.1]     (state order: "0","1","2","3")
+#   R  = [0.25, 0.15, 0.10, 0.20, 0.10, 0.20]   (row-major upper triangle)
+#   mu = 0.2
+#   N  = 400 taxa, Yule(lambda=1)
+
+set -eu
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+SEED="${SEED:-42}"
+NUM_RESULTS="${NUM_RESULTS:-1000}"
+NUM_BURNIN="${NUM_BURNIN:-500}"
+
+: "${LPHY:=$HOME/Git/linguaPhylo/lphy-studio/target/lphy-studio-1.7.0}"
+: "${SLPHY:=$HOME/Git/linguaPhylo/bin/slphy}"
+: "${TREEFLOW_PY:=$HOME/Git/treeflow/.venv/bin/python}"
+: "${TREEFLOW_DTA_HMC:=$HOME/Git/treeflow/.venv/bin/treeflow_dta_hmc}"
+
+cd "$DIR"
+
+echo "[1/3] Simulating with LPhy (seed=$SEED)..."
+LPHY="$LPHY" "$SLPHY" dta-validation.lphy -seed "$SEED"
+
+echo "[2/3] Converting nexus -> traits.csv + tree.nwk..."
+"$TREEFLOW_PY" convert.py
+
+echo "[3/3] Running treeflow_dta_hmc ($NUM_BURNIN burn-in + $NUM_RESULTS samples)..."
+"$TREEFLOW_DTA_HMC" \
+  --traits traits.csv \
+  --topology tree.nwk \
+  --model-file model.yaml \
+  --num-results "$NUM_RESULTS" \
+  --num-burnin-steps "$NUM_BURNIN" \
+  --samples-output samples.csv \
+  --seed "$SEED"
+
+echo "Summarising posterior vs truth..."
+"$TREEFLOW_PY" summarize.py --samples samples.csv
+
+echo "Done. Samples in $DIR/samples.csv"

--- a/examples/dta-validation/summarize.py
+++ b/examples/dta-validation/summarize.py
@@ -1,0 +1,78 @@
+"""Summarise treeflow_dta_hmc posterior vs simulation truth.
+
+Reads samples.csv produced by treeflow_dta_hmc and compares posterior
+mean / 95% CI / ESS for each π and R parameter against the fixed truth
+encoded in dta-validation.lphy.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+# Truth from dta-validation.lphy. State order: "0","1","2","3"
+# (lexicographic, matches DiscreteTraitData default).
+# Rate order: row-major upper triangle — (0,1),(0,2),(0,3),(1,2),(1,3),(2,3).
+TRUTH_PI = [0.4, 0.3, 0.2, 0.1]
+TRUTH_R = [0.25, 0.15, 0.10, 0.20, 0.10, 0.20]
+RATE_LABELS = ["(0,1)", "(0,2)", "(0,3)", "(1,2)", "(1,3)", "(2,3)"]
+
+
+def ess_ar1(x: np.ndarray, max_lag: int = 500, cutoff: float = 0.05) -> float:
+    """ESS via autocorrelation sum, cut when |r_k| drops below `cutoff`."""
+    x = np.asarray(x, dtype=float) - np.mean(x)
+    n = len(x)
+    denom = float((x * x).sum())
+    if denom == 0.0:
+        return float(n)
+    r = np.correlate(x, x, mode="full")[n - 1:] / denom
+    s = 1.0
+    for k in range(1, min(n, max_lag)):
+        if abs(r[k]) < cutoff:
+            break
+        s += 2 * r[k]
+    return float(n) / max(s, 1.0)
+
+
+def summarise(samples_csv: Path) -> None:
+    df = pd.read_csv(samples_csv)
+    print(f"Loaded {len(df)} samples from {samples_csv}")
+    print(f"Columns: {list(df.columns)}\n")
+
+    header = f"{'param':<10}{'label':<10}{'truth':>8}{'mean':>10}{'q025':>10}{'q975':>10}{'cover':>8}{'ess':>10}"
+    print(header)
+    print("-" * len(header))
+
+    rows: list[tuple[str, str, float, float, float, float, bool, float]] = []
+    for i, t in enumerate(TRUTH_PI):
+        s = df[f"frequencies_{i}"].to_numpy()
+        lo, hi = float(np.quantile(s, 0.025)), float(np.quantile(s, 0.975))
+        rows.append((f"pi_{i}", str(i), t, float(np.mean(s)), lo, hi, lo <= t <= hi, ess_ar1(s)))
+    for i, t in enumerate(TRUTH_R):
+        s = df[f"rates_{i}"].to_numpy()
+        lo, hi = float(np.quantile(s, 0.025)), float(np.quantile(s, 0.975))
+        rows.append((f"R_{i}", RATE_LABELS[i], t, float(np.mean(s)), lo, hi, lo <= t <= hi, ess_ar1(s)))
+
+    for name, label, truth, mean, lo, hi, cov, ess in rows:
+        cov_mark = "Y" if cov else "N"
+        print(f"{name:<10}{label:<10}{truth:>8.3f}{mean:>10.3f}{lo:>10.3f}{hi:>10.3f}{cov_mark:>8}{ess:>10.1f}")
+
+    n_cov = sum(1 for r in rows if r[6])
+    print(f"\nCoverage: {n_cov}/{len(rows)} parameters inside 95% CI")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--samples",
+        type=Path,
+        default=Path(__file__).parent / "samples.csv",
+    )
+    args = ap.parse_args()
+    summarise(args.samples)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ console_scripts =
     treeflow_vi = treeflow.cli.vi:treeflow_vi
     treeflow_ml = treeflow.cli.ml:treeflow_ml
     treeflow_hmc = treeflow.cli.hmc:treeflow_hmc
+    treeflow_dta_hmc = treeflow.cli.dta_hmc:treeflow_dta_hmc
 
 
 [options.extras_require]

--- a/test/cli/test_dta_hmc_cli.py
+++ b/test/cli/test_dta_hmc_cli.py
@@ -1,0 +1,121 @@
+"""End-to-end CLI test for treeflow_dta_hmc."""
+import textwrap
+
+import pandas as pd
+import pytest
+from click.testing import CliRunner
+
+from treeflow.cli.dta_hmc import treeflow_dta_hmc
+
+pytestmark = pytest.mark.cli
+
+
+@pytest.fixture
+def tiny_dta_inputs(tmp_path):
+    tree_path = tmp_path / "tree.nwk"
+    tree_path.write_text("((mars:0.1,saturn:0.1):0.2,jupiter:0.3);\n")
+
+    traits_path = tmp_path / "traits.csv"
+    traits_path.write_text(
+        textwrap.dedent(
+            """\
+            taxon,trait
+            mars,A
+            saturn,B
+            jupiter,C
+            """
+        )
+    )
+
+    model_path = tmp_path / "model.yaml"
+    model_path.write_text(
+        textwrap.dedent(
+            """\
+            tree: fixed
+            clock:
+              strict:
+                clock_rate: 0.5
+            substitution:
+              discrete_trait:
+                n_states: 3
+                frequencies:
+                  dirichlet:
+                    concentration: [1.0, 1.0, 1.0]
+                rates:
+                  dirichlet:
+                    concentration: [1.0, 1.0, 1.0]
+            site: none
+            """
+        )
+    )
+
+    return tree_path, traits_path, model_path
+
+
+def test_dta_hmc_cli_end_to_end(tiny_dta_inputs, tmp_path):
+    tree_path, traits_path, model_path = tiny_dta_inputs
+    samples_output = tmp_path / "samples.csv"
+
+    runner = CliRunner()
+    num_results = 10
+    res = runner.invoke(
+        treeflow_dta_hmc,
+        [
+            "-r", str(traits_path),
+            "-t", str(tree_path),
+            "-m", str(model_path),
+            "-n", str(num_results),
+            "--num-burnin-steps", "3",
+            "--num-adaptation-steps", "3",
+            "--num-leapfrog-steps", "3",
+            "--kernel", "nuts",
+            "--samples-output", str(samples_output),
+            "--seed", "42",
+        ],
+        catch_exceptions=False,
+    )
+    assert res.exit_code == 0, res.stdout
+    assert samples_output.exists()
+    samples = pd.read_csv(samples_output)
+    assert samples.shape[0] == num_results
+
+
+def test_dta_hmc_cli_mismatched_n_states(tiny_dta_inputs, tmp_path):
+    """Model declares 4 states but traits only observe 3: CLI must refuse."""
+    tree_path, traits_path, _ = tiny_dta_inputs
+    bad_model_path = tmp_path / "model_bad.yaml"
+    bad_model_path.write_text(
+        textwrap.dedent(
+            """\
+            tree: fixed
+            clock:
+              strict:
+                clock_rate: 0.5
+            substitution:
+              discrete_trait:
+                n_states: 4
+                frequencies:
+                  dirichlet:
+                    concentration: [1.0, 1.0, 1.0, 1.0]
+                rates:
+                  dirichlet:
+                    concentration: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+            site: none
+            """
+        )
+    )
+
+    runner = CliRunner()
+    res = runner.invoke(
+        treeflow_dta_hmc,
+        [
+            "-r", str(traits_path),
+            "-t", str(tree_path),
+            "-m", str(bad_model_path),
+            "-n", "2",
+            "--num-burnin-steps", "1",
+        ],
+        catch_exceptions=False,
+    )
+    assert res.exit_code != 0
+    assert "n_states" in res.output

--- a/test/evolution/substitution/discrete_trait/test_dta.py
+++ b/test/evolution/substitution/discrete_trait/test_dta.py
@@ -1,0 +1,89 @@
+import numpy as np
+import pytest
+import tensorflow as tf
+from numpy.testing import assert_allclose
+
+from treeflow.evolution.substitution.discrete_trait.dta import DiscreteTraitModel
+from treeflow.evolution.substitution.nucleotide.jc import JC
+
+
+@pytest.mark.parametrize("n_states", [2, 3, 4, 5, 8])
+def test_q_shape_and_zero_row_sums(tensor_constant, n_states):
+    model = DiscreteTraitModel(n_states)
+    n_rates = n_states * (n_states - 1) // 2
+    frequencies = tensor_constant(np.full(n_states, 1.0 / n_states))
+    rates = tensor_constant(np.linspace(0.5, 1.5, n_rates))
+
+    q = model.q(frequencies=frequencies, rates=rates)
+
+    assert q.shape == (n_states, n_states)
+    row_sums = tf.reduce_sum(q, axis=-1).numpy()
+    assert_allclose(row_sums, np.zeros(n_states), atol=1e-10)
+
+
+def test_time_reversibility(tensor_constant):
+    # pi_i Q_ij == pi_j Q_ji for all i != j
+    K = 5
+    model = DiscreteTraitModel(K)
+    pi = np.array([0.10, 0.15, 0.20, 0.25, 0.30])
+    rates = np.linspace(0.3, 1.7, K * (K - 1) // 2)
+    q = model.q(
+        frequencies=tensor_constant(pi), rates=tensor_constant(rates)
+    ).numpy()
+
+    lhs = pi[:, None] * q
+    # lhs[i, j] = pi_i * Q_ij should equal lhs[j, i] = pi_j * Q_ji
+    assert_allclose(lhs, lhs.T, atol=1e-12)
+
+
+def test_reduces_to_jc_when_k4_equal_rates(tensor_constant):
+    """With K=4, equal frequencies, and equal rates, Q_norm should match JC."""
+    K = 4
+    model = DiscreteTraitModel(K)
+    pi = tensor_constant(np.full(K, 1.0 / K))
+    rates = tensor_constant(np.ones(K * (K - 1) // 2))
+
+    q_dta = model.q_norm(frequencies=pi, rates=rates).numpy()
+    q_jc = JC().q_norm(frequencies=pi).numpy()
+    assert_allclose(q_dta, q_jc, atol=1e-12)
+
+
+def test_eigendecomposition_roundtrip(tensor_constant):
+    K = 6
+    model = DiscreteTraitModel(K)
+    pi = tensor_constant(np.array([0.05, 0.10, 0.15, 0.20, 0.25, 0.25]))
+    rates = tensor_constant(np.linspace(0.2, 2.0, K * (K - 1) // 2))
+
+    eig = model.eigen(frequencies=pi, rates=rates)
+    q_reconstructed = (
+        eig.eigenvectors @ tf.linalg.diag(eig.eigenvalues) @ eig.inverse_eigenvectors
+    )
+    q_norm = model.q_norm(frequencies=pi, rates=rates)
+    assert_allclose(q_reconstructed.numpy(), q_norm.numpy(), atol=1e-10)
+
+
+def test_batched_rates(tensor_constant):
+    """Support a leading batch dimension on rates and frequencies."""
+    K = 4
+    batch = 3
+    model = DiscreteTraitModel(K)
+    rng = np.random.default_rng(0)
+    pi = rng.dirichlet(np.ones(K), size=batch)
+    rates = rng.uniform(0.1, 2.0, size=(batch, K * (K - 1) // 2))
+
+    q = model.q(
+        frequencies=tensor_constant(pi), rates=tensor_constant(rates)
+    ).numpy()
+
+    assert q.shape == (batch, K, K)
+    for b in range(batch):
+        row_sums = q[b].sum(axis=-1)
+        assert_allclose(row_sums, np.zeros(K), atol=1e-10)
+        # reversibility per batch element
+        lhs = pi[b][:, None] * q[b]
+        assert_allclose(lhs, lhs.T, atol=1e-10)
+
+
+def test_invalid_n_states():
+    with pytest.raises(ValueError):
+        DiscreteTraitModel(1)

--- a/test/evolution/test_traitio.py
+++ b/test/evolution/test_traitio.py
@@ -1,0 +1,166 @@
+import os
+import textwrap
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from treeflow.evolution.traitio import (
+    DiscreteTraitData,
+    TraitDataParseError,
+    parse_trait_csv,
+)
+
+
+@pytest.fixture
+def example_mapping():
+    return {
+        "taxon_A": "NY",
+        "taxon_B": "HK",
+        "taxon_C": "NZ",
+        "taxon_D": "NY",
+    }
+
+
+def test_from_mapping_infers_sorted_states(example_mapping):
+    data = DiscreteTraitData(trait_mapping=example_mapping)
+    assert data.states == ("HK", "NY", "NZ")
+    assert data.n_states == 3
+    assert data.taxon_count == 4
+
+
+def test_encoded_array_layout_and_onehot(example_mapping):
+    data = DiscreteTraitData(trait_mapping=example_mapping)
+    arr = data.get_encoded_trait_array(
+        ["taxon_A", "taxon_B", "taxon_C", "taxon_D"]
+    )
+    assert arr.shape == (1, 4, 3)  # [sites=1, taxa, states]
+    # HK=0, NY=1, NZ=2 after sorting
+    expected = np.array(
+        [
+            [
+                [0, 1, 0],  # taxon_A -> NY
+                [1, 0, 0],  # taxon_B -> HK
+                [0, 0, 1],  # taxon_C -> NZ
+                [0, 1, 0],  # taxon_D -> NY
+            ]
+        ],
+        dtype=np.float64,
+    )
+    assert_allclose(arr, expected)
+
+
+def test_taxon_reordering(example_mapping):
+    data = DiscreteTraitData(trait_mapping=example_mapping)
+    a = data.get_encoded_trait_array(
+        ["taxon_A", "taxon_B", "taxon_C", "taxon_D"]
+    )
+    b = data.get_encoded_trait_array(
+        ["taxon_C", "taxon_A", "taxon_D", "taxon_B"]
+    )
+    # Row permutation by [2, 0, 3, 1]
+    assert_allclose(b[0], a[0][[2, 0, 3, 1]])
+
+
+def test_unknown_state_is_flat_partials():
+    data = DiscreteTraitData(
+        trait_mapping={"t1": "A", "t2": "B", "t3": "?"},
+        states=("A", "B"),
+    )
+    arr = data.get_encoded_trait_array(["t1", "t2", "t3"])
+    assert_allclose(arr[0, 0], [1.0, 0.0])
+    assert_allclose(arr[0, 1], [0.0, 1.0])
+    assert_allclose(arr[0, 2], [1.0, 1.0])
+
+
+def test_explicit_states_ordering():
+    data = DiscreteTraitData(
+        trait_mapping={"t1": "NY", "t2": "HK", "t3": "NZ"},
+        states=("NY", "HK", "NZ"),
+    )
+    assert data.states == ("NY", "HK", "NZ")
+    arr = data.get_encoded_trait_array(["t1", "t2", "t3"])
+    # NY=0, HK=1, NZ=2 under explicit ordering
+    assert_allclose(arr[0, 0], [1.0, 0.0, 0.0])
+    assert_allclose(arr[0, 1], [0.0, 1.0, 0.0])
+    assert_allclose(arr[0, 2], [0.0, 0.0, 1.0])
+
+
+def test_explicit_states_must_cover_observed():
+    with pytest.raises(TraitDataParseError, match="not present"):
+        DiscreteTraitData(
+            trait_mapping={"t1": "A", "t2": "B", "t3": "C"},
+            states=("A", "B"),
+        )
+
+
+def test_requires_at_least_two_states():
+    with pytest.raises(TraitDataParseError, match="at least two"):
+        DiscreteTraitData(trait_mapping={"t1": "A", "t2": "A"})
+
+
+def test_missing_taxon_on_encode(example_mapping):
+    data = DiscreteTraitData(trait_mapping=example_mapping)
+    with pytest.raises(TraitDataParseError, match="not present"):
+        data.get_encoded_trait_array(["taxon_A", "taxon_ZZZ"])
+
+
+def test_mutually_exclusive_sources():
+    with pytest.raises(ValueError, match="Exactly one"):
+        DiscreteTraitData()
+    with pytest.raises(ValueError, match="Exactly one"):
+        DiscreteTraitData(csv_file="foo", trait_mapping={"t": "A"})
+
+
+def test_csv_roundtrip(tmp_path):
+    csv_path = tmp_path / "traits.csv"
+    csv_path.write_text(
+        textwrap.dedent(
+            """\
+            taxon,trait
+            t1,NY
+            t2,HK
+            t3,NZ
+            t4,?
+            """
+        )
+    )
+    data = DiscreteTraitData(csv_file=str(csv_path))
+    assert data.states == ("HK", "NY", "NZ")
+    arr = data.get_encoded_trait_array(["t1", "t2", "t3", "t4"])
+    assert arr.shape == (1, 4, 3)
+    assert_allclose(arr[0, 3], [1.0, 1.0, 1.0])  # unknown -> flat
+
+
+def test_csv_custom_column_names(tmp_path):
+    csv_path = tmp_path / "traits_custom.csv"
+    csv_path.write_text("name,deme\nt1,A\nt2,B\n")
+    data = DiscreteTraitData(
+        csv_file=str(csv_path), taxon_column="name", trait_column="deme"
+    )
+    assert data.taxon_count == 2
+    assert data.states == ("A", "B")
+
+
+def test_csv_missing_column(tmp_path):
+    csv_path = tmp_path / "traits_bad.csv"
+    csv_path.write_text("taxon\nt1\nt2\n")
+    with pytest.raises(TraitDataParseError, match="missing required column"):
+        DiscreteTraitData(csv_file=str(csv_path))
+
+
+def test_csv_duplicate_taxon(tmp_path):
+    csv_path = tmp_path / "traits_dup.csv"
+    csv_path.write_text("taxon,trait\nt1,A\nt1,B\n")
+    with pytest.raises(TraitDataParseError, match="Duplicate"):
+        DiscreteTraitData(csv_file=str(csv_path))
+
+
+def test_encoded_tensor_dtype():
+    import tensorflow as tf
+
+    data = DiscreteTraitData(trait_mapping={"t1": "A", "t2": "B"})
+    t = data.get_encoded_trait_tensor(["t1", "t2"])
+    assert isinstance(t, tf.Tensor)
+    # Default dtype should be treeflow's default float
+    assert t.shape == (1, 2, 2)

--- a/test/model/test_phylo_model_discrete_trait.py
+++ b/test/model/test_phylo_model_discrete_trait.py
@@ -1,0 +1,182 @@
+"""End-to-end integration tests for the `discrete_trait` substitution block.
+
+Exercises the full path from a PhyloModel dict with a discrete_trait
+substitution model, through joint distribution construction, to log_prob
+evaluation on a small 3-taxon tree.
+"""
+import numpy as np
+import pytest
+import tensorflow as tf
+from numpy.testing import assert_allclose
+
+from treeflow.evolution.traitio import DiscreteTraitData
+from treeflow.model.phylo_model import (
+    DISCRETE_TRAIT_KEY,
+    PhyloModel,
+    PhyloModelParseError,
+    get_subst_model,
+    phylo_model_to_joint_distribution,
+)
+from treeflow.evolution.substitution.discrete_trait.dta import DiscreteTraitModel
+
+
+@pytest.fixture
+def hello_traits():
+    """A discrete-trait assignment for the 3 hello tips."""
+    return DiscreteTraitData(
+        trait_mapping={"mars": "A", "saturn": "B", "jupiter": "C"},
+    )
+
+
+@pytest.fixture
+def hello_discrete_trait_model_dict():
+    """A minimal discrete_trait phylo model for the 3-taxon hello tree.
+
+    K = 3 states (`A`, `B`, `C`) => K*(K-1)/2 = 3 exchangeability rates.
+    """
+    return dict(
+        tree="fixed",
+        clock=dict(strict=dict(clock_rate=0.5)),
+        substitution=dict(
+            discrete_trait=dict(
+                n_states=3,
+                frequencies=dict(
+                    dirichlet=dict(concentration=[1.0, 1.0, 1.0]),
+                ),
+                rates=dict(
+                    dirichlet=dict(concentration=[1.0, 1.0, 1.0]),
+                ),
+            )
+        ),
+        site="none",
+    )
+
+
+def test_get_subst_model_returns_dta_with_k():
+    model = get_subst_model(DISCRETE_TRAIT_KEY, dict(n_states=5))
+    assert isinstance(model, DiscreteTraitModel)
+    assert model.n_states == 5
+
+
+def test_get_subst_model_requires_n_states():
+    with pytest.raises(PhyloModelParseError, match="n_states"):
+        get_subst_model(DISCRETE_TRAIT_KEY, None)
+    with pytest.raises(PhyloModelParseError, match="n_states"):
+        get_subst_model(DISCRETE_TRAIT_KEY, {})
+
+
+def test_phylo_model_parses_discrete_trait(hello_discrete_trait_model_dict):
+    model = PhyloModel(hello_discrete_trait_model_dict)
+    assert model.subst_model == DISCRETE_TRAIT_KEY
+    assert model.subst_params["n_states"] == 3
+    # Free-parameter extraction should pick up the two priors but not n_states.
+    free = model.free_params()
+    assert "frequencies" in free
+    assert "rates" in free
+    assert "n_states" not in free
+
+
+def test_joint_distribution_samples_and_evaluates(
+    hello_tensor_tree, hello_traits, hello_discrete_trait_model_dict
+):
+    model = PhyloModel(hello_discrete_trait_model_dict)
+    dist = phylo_model_to_joint_distribution(
+        model, hello_tensor_tree, hello_traits
+    )
+
+    sample = dist.sample()
+    keys = set(sample._asdict().keys())
+    # The free parameters plus the observation named "alignment" (duck-typed).
+    assert "frequencies" in keys
+    assert "rates" in keys
+    assert "alignment" in keys
+
+    # Sampled rates should be a 3-simplex; frequencies a 3-simplex.
+    assert sample.frequencies.shape[-1] == 3
+    assert sample.rates.shape[-1] == 3  # K*(K-1)/2 == 3 for K=3
+    assert_allclose(
+        tf.reduce_sum(sample.frequencies, axis=-1).numpy(), 1.0, atol=1e-6
+    )
+    assert_allclose(tf.reduce_sum(sample.rates, axis=-1).numpy(), 1.0, atol=1e-6)
+
+    # log_prob must be finite at the sampled state.
+    lp = dist.log_prob(sample)
+    assert np.isfinite(lp.numpy())
+
+
+def test_log_prob_at_fixed_state(
+    hello_tensor_tree, hello_traits, hello_discrete_trait_model_dict
+):
+    """Evaluate log_prob at a concrete parameter vector and confirm finiteness
+    plus observation-vs-prior decomposition.
+
+    With a fixed sample we can pin the joint log density down and check that
+    changing observations (swapping trait labels) moves the value.
+    """
+    model = PhyloModel(hello_discrete_trait_model_dict)
+    dist = phylo_model_to_joint_distribution(
+        model, hello_tensor_tree, hello_traits
+    )
+    sample = dist.sample(seed=(1, 2))
+
+    # Fix the parameters, evaluate at the observed data vs a flipped-label
+    # version of the observed data.
+    observed_alignment = sample.alignment.numpy().copy()
+    flipped_alignment = observed_alignment[:, ::-1, :].copy()  # reverse taxa
+
+    lp_observed = dist.log_prob(sample)
+
+    sample_flipped = sample._replace(alignment=tf.constant(flipped_alignment))
+    lp_flipped = dist.log_prob(sample_flipped)
+
+    assert np.isfinite(lp_observed.numpy())
+    assert np.isfinite(lp_flipped.numpy())
+    # The priors are identical; any difference comes from the likelihood.
+    # With distinct tip states, flipping the observation changes likelihood
+    # (and therefore the joint log-density).
+    assert lp_observed.numpy() != lp_flipped.numpy()
+
+
+@pytest.mark.parametrize("n_states", [3, 4, 6])
+def test_discrete_trait_models_at_various_k(
+    hello_tensor_tree, n_states
+):
+    """Build and evaluate discrete_trait models for a handful of K values.
+
+    K=2 is skipped: the single exchange rate is degenerate after
+    normalisation, so a Dirichlet rates prior is undefined.
+    """
+    # Build a consistent trait mapping and dimensions
+    state_labels = [chr(ord("A") + i) for i in range(n_states)]
+    traits = DiscreteTraitData(
+        trait_mapping={
+            "mars": state_labels[0],
+            "saturn": state_labels[1 % n_states],
+            "jupiter": state_labels[(n_states - 1) % n_states],
+        },
+        states=tuple(state_labels),
+    )
+    n_rates = n_states * (n_states - 1) // 2
+    model_dict = dict(
+        tree="fixed",
+        clock=dict(strict=dict(clock_rate=0.1)),
+        substitution=dict(
+            discrete_trait=dict(
+                n_states=n_states,
+                frequencies=dict(
+                    dirichlet=dict(concentration=[1.0] * n_states),
+                ),
+                rates=dict(
+                    dirichlet=dict(concentration=[1.0] * n_rates),
+                ),
+            )
+        ),
+        site="none",
+    )
+    model = PhyloModel(model_dict)
+    dist = phylo_model_to_joint_distribution(model, hello_tensor_tree, traits)
+    sample = dist.sample()
+    assert sample.frequencies.shape[-1] == n_states
+    assert sample.rates.shape[-1] == n_rates
+    lp = dist.log_prob(sample)
+    assert np.isfinite(lp.numpy())

--- a/treeflow/cli/dta_hmc.py
+++ b/treeflow/cli/dta_hmc.py
@@ -1,0 +1,302 @@
+"""CLI entry point for discrete-trait (phylogeography / DTA) HMC/NUTS on a
+fixed time-tree.
+
+Parallels ``treeflow_hmc`` but loads a two-column CSV of tip traits instead
+of an alignment.
+"""
+from __future__ import annotations
+
+import click
+import tensorflow as tf
+import yaml
+
+from treeflow import DEFAULT_FLOAT_DTYPE_TF
+from treeflow.cli.inference_common import (
+    InitialValueParseError,
+    get_tree_vars,
+    parse_init_values,
+    write_trees,
+)
+from treeflow.evolution.traitio import DiscreteTraitData, TraitDataParseError
+from treeflow.model.io import write_samples_to_file
+from treeflow.model.phylo_model import (
+    DEFAULT_TREE_VAR_NAME,
+    DISCRETE_TRAIT_KEY,
+    PhyloModel,
+    PhyloModelParseError,
+    phylo_model_to_joint_distribution,
+)
+from treeflow.tree.io import TreeParseError, parse_newick
+from treeflow.tree.rooted.tensorflow_rooted_tree import convert_tree_to_tensor
+from treeflow.vi.hmc import KERNEL_HMC, KERNEL_NUTS, fit_fixed_topology_hmc
+
+KERNEL_CHOICES = [KERNEL_HMC, KERNEL_NUTS]
+
+DEFAULT_TAXON_COLUMN = "taxon"
+DEFAULT_TRAIT_COLUMN = "trait"
+
+
+@click.command()
+@click.option(
+    "-r",
+    "--traits",
+    required=True,
+    type=click.Path(exists=True),
+    help="CSV file of discrete tip traits (two columns: taxon and trait).",
+)
+@click.option(
+    "-t",
+    "--topology",
+    required=True,
+    type=click.Path(exists=True),
+    help="Fixed Newick tree file (branch lengths in time units).",
+)
+@click.option(
+    "-m",
+    "--model-file",
+    required=True,
+    type=click.Path(exists=True),
+    help="YAML model definition file (must contain a `discrete_trait` "
+    "substitution block).",
+)
+@click.option(
+    "-n",
+    "--num-results",
+    type=int,
+    default=1000,
+    show_default=True,
+    help="Number of MCMC samples to collect after burn-in",
+)
+@click.option(
+    "--num-burnin-steps",
+    type=int,
+    default=500,
+    show_default=True,
+    help="Number of burn-in steps (discarded)",
+)
+@click.option(
+    "--num-adaptation-steps",
+    type=int,
+    default=None,
+    help="Steps for dual-averaging step-size adaptation "
+    "(default: num-burnin-steps)",
+)
+@click.option(
+    "--step-size",
+    type=float,
+    default=0.01,
+    show_default=True,
+    help="Initial leapfrog step size",
+)
+@click.option(
+    "--num-leapfrog-steps",
+    type=int,
+    default=10,
+    show_default=True,
+    help="Number of leapfrog steps per HMC proposal (ignored for NUTS)",
+)
+@click.option(
+    "--kernel",
+    type=click.Choice(KERNEL_CHOICES),
+    default=KERNEL_NUTS,
+    show_default=True,
+    help="MCMC kernel type",
+)
+@click.option(
+    "--init-values",
+    required=False,
+    type=str,
+    help="Initial values: 'scalar=v1,vector=v2a|v2b'",
+)
+@click.option("-s", "--seed", required=False, type=int)
+@click.option(
+    "--samples-output",
+    required=False,
+    type=click.Path(),
+    help="Path to save parameter samples (CSV).",
+)
+@click.option(
+    "--taxon-column",
+    type=str,
+    default=DEFAULT_TAXON_COLUMN,
+    show_default=True,
+    help="Name of the column in the traits CSV holding taxon labels.",
+)
+@click.option(
+    "--trait-column",
+    type=str,
+    default=DEFAULT_TRAIT_COLUMN,
+    show_default=True,
+    help="Name of the column in the traits CSV holding discrete trait labels.",
+)
+@click.option(
+    "--states",
+    type=str,
+    default=None,
+    help="Comma-separated explicit ordering of trait states "
+    "(defaults to sorted unique labels observed in the CSV).",
+)
+@click.option(
+    "--subnewick-format",
+    type=int,
+    default=0,
+    show_default=True,
+    help="Subnewick format (see `ete3.Tree`)",
+)
+def treeflow_dta_hmc(
+    traits,
+    topology,
+    model_file,
+    num_results,
+    num_burnin_steps,
+    num_adaptation_steps,
+    step_size,
+    num_leapfrog_steps,
+    kernel,
+    init_values,
+    seed,
+    samples_output,
+    taxon_column,
+    trait_column,
+    states,
+    subnewick_format,
+):
+    """Fixed-topology HMC/NUTS inference for a discrete-trait (DTA /
+    phylogeography) model on a fixed time-tree.
+
+    Given a Newick tree with branch lengths in time units and a CSV of tip
+    trait labels, runs NUTS (default) or HMC to sample the posterior over
+    exchange rates, equilibrium frequencies, and any other free parameters
+    declared in the YAML model file.
+    """
+    print(f"Parsing topology {topology}")
+    try:
+        tree = convert_tree_to_tensor(
+            parse_newick(topology, subnewick_format=subnewick_format)
+        )
+    except TreeParseError as ex:
+        raise click.ClickException(str(ex))
+
+    print(f"Parsing traits {traits}")
+    state_tuple = None if states is None else tuple(
+        s.strip() for s in states.split(",")
+    )
+    try:
+        trait_data = DiscreteTraitData(
+            csv_file=traits,
+            states=state_tuple,
+            taxon_column=taxon_column,
+            trait_column=trait_column,
+        )
+    except TraitDataParseError as ex:
+        raise click.ClickException(str(ex))
+
+    tree_taxa = list(tree.taxon_set)
+    missing = set(tree_taxa) - set(trait_data.trait_mapping.keys())
+    if missing:
+        raise click.ClickException(
+            f"Traits CSV is missing {len(missing)} taxa present in the "
+            f"tree: {sorted(missing)[:5]}{'...' if len(missing) > 5 else ''}"
+        )
+
+    encoded_traits = trait_data.get_encoded_trait_tensor(tree_taxa)
+    print(
+        f"  {trait_data.taxon_count} tips, {trait_data.n_states} states: "
+        f"{list(trait_data.states)}"
+    )
+
+    print("Parsing model...")
+    with open(model_file) as f:
+        model_dict = yaml.safe_load(f)
+    try:
+        phylo_model = PhyloModel(model_dict)
+    except PhyloModelParseError as ex:
+        raise click.ClickException(str(ex))
+
+    if phylo_model.subst_model != DISCRETE_TRAIT_KEY:
+        raise click.ClickException(
+            f"Expected substitution model {DISCRETE_TRAIT_KEY!r} in model "
+            f"file, got {phylo_model.subst_model!r}."
+        )
+    declared_n_states = int(phylo_model.subst_params["n_states"])
+    if declared_n_states != trait_data.n_states:
+        raise click.ClickException(
+            f"Model declares n_states={declared_n_states} but the traits "
+            f"CSV contains {trait_data.n_states} observed states "
+            f"({list(trait_data.states)}). Either fix the model or pass "
+            f"--states to include unobserved states in the state space."
+        )
+
+    model = phylo_model_to_joint_distribution(phylo_model, tree, trait_data)
+    pinned_model = model.experimental_pin(alignment=encoded_traits)
+    model_names = set(pinned_model._flat_resolve_names())
+
+    print("Parsing initial values...")
+    try:
+        init_values_dict = (
+            None
+            if init_values is None
+            else {
+                key: tf.constant(value, dtype=DEFAULT_FLOAT_DTYPE_TF)
+                for key, value in parse_init_values(
+                    init_values, model_names=model_names
+                ).items()
+            }
+        )
+    except InitialValueParseError as ex:
+        raise click.ClickException(str(ex))
+
+    if init_values_dict is None:
+        init_state = None
+    else:
+        init_state = {
+            key: value
+            for key, value in init_values_dict.items()
+            if key in model_names
+        }
+        init_state[DEFAULT_TREE_VAR_NAME] = tree
+
+    total_steps = num_results + num_burnin_steps
+    print(
+        f"Running {kernel}: {num_burnin_steps} burn-in + {num_results} "
+        f"sampling steps ({total_steps} total)..."
+    )
+    hmc_res = fit_fixed_topology_hmc(
+        model=pinned_model,
+        topologies={DEFAULT_TREE_VAR_NAME: tree.topology},
+        num_results=num_results,
+        num_burnin_steps=num_burnin_steps,
+        num_adaptation_steps=num_adaptation_steps,
+        step_size=step_size,
+        num_leapfrog_steps=num_leapfrog_steps,
+        kernel=kernel,
+        init_state=init_state,
+        seed=seed,
+    )
+    print("Sampling complete")
+
+    if samples_output is not None:
+        constrained_samples = hmc_res.samples
+        names = pinned_model._flat_resolve_names()
+        flat_samples = pinned_model._model_flatten(constrained_samples)
+        samples_dict = dict(zip(names, flat_samples))
+
+        tree_vars = get_tree_vars(phylo_model)
+        tree_samples = {
+            var: samples_dict.pop(var) for var in tree_vars if var in samples_dict
+        }
+
+        print(f"Saving samples to {samples_output}...")
+        write_samples_to_file(
+            constrained_samples,
+            pinned_model,
+            samples_output,
+            vars=samples_dict.keys(),
+            tree_vars=(
+                {DEFAULT_TREE_VAR_NAME: tree_samples[DEFAULT_TREE_VAR_NAME]}
+                if DEFAULT_TREE_VAR_NAME in tree_samples
+                else None
+            ),
+        )
+
+    print("Exiting...")

--- a/treeflow/evolution/substitution/discrete_trait/__init__.py
+++ b/treeflow/evolution/substitution/discrete_trait/__init__.py
@@ -1,0 +1,3 @@
+from treeflow.evolution.substitution.discrete_trait.dta import DiscreteTraitModel
+
+__all__ = ["DiscreteTraitModel"]

--- a/treeflow/evolution/substitution/discrete_trait/dta.py
+++ b/treeflow/evolution/substitution/discrete_trait/dta.py
@@ -1,0 +1,81 @@
+import tensorflow as tf
+
+from treeflow.evolution.substitution.base_substitution_model import (
+    EigendecompositionSubstitutionModel,
+)
+
+
+class DiscreteTraitModel(EigendecompositionSubstitutionModel):
+    """Time-reversible K-state discrete-trait substitution model.
+
+    Follows the parameterisation of Lemey et al. (2009) for Bayesian
+    phylogeography: Q[i,j] = rate[pair(i,j)] * pi[j] for i != j, and the
+    diagonal is set to ensure zero row sums.
+
+    The rate vector carries the K*(K-1)/2 symmetric exchange rates in
+    row-major upper-triangular order: (0,1), (0,2), ..., (0,K-1),
+    (1,2), (1,3), ..., (K-2, K-1).
+    """
+
+    def __init__(self, n_states: int):
+        if n_states < 2:
+            raise ValueError(f"n_states must be >= 2, got {n_states}")
+        self.n_states = int(n_states)
+        self._upper_indices = _upper_triangle_indices(self.n_states)
+
+    def q(self, frequencies: tf.Tensor, rates: tf.Tensor) -> tf.Tensor:
+        K = self.n_states
+        expected_rates = K * (K - 1) // 2
+        rates = tf.convert_to_tensor(rates)
+        frequencies = tf.convert_to_tensor(frequencies)
+
+        tf.debugging.assert_equal(
+            tf.shape(rates)[-1],
+            expected_rates,
+            message=(
+                f"DiscreteTraitModel({K}) expects rates of length "
+                f"{expected_rates} (K*(K-1)/2)."
+            ),
+        )
+        tf.debugging.assert_equal(
+            tf.shape(frequencies)[-1],
+            K,
+            message=f"DiscreteTraitModel({K}) expects frequencies of length {K}.",
+        )
+
+        exchange = _scatter_symmetric(rates, K, self._upper_indices)
+        pi_row = frequencies[..., tf.newaxis, :]
+
+        off_diag = exchange * pi_row
+        row_sum = tf.reduce_sum(off_diag, axis=-1)
+        q = tf.linalg.set_diag(off_diag, -row_sum)
+        return q
+
+
+def _upper_triangle_indices(K: int) -> tf.Tensor:
+    """(K*(K-1)/2, 2) int32 tensor of (i, j) pairs with i < j, row-major."""
+    pairs = [(i, j) for i in range(K) for j in range(i + 1, K)]
+    return tf.constant(pairs, dtype=tf.int32)
+
+
+def _scatter_symmetric(
+    rates: tf.Tensor, K: int, upper_indices: tf.Tensor
+) -> tf.Tensor:
+    """Build a (..., K, K) symmetric matrix with zero diagonal from a
+    (..., K*(K-1)/2) row-major upper-triangular rate vector."""
+    batch_shape = tf.shape(rates)[:-1]
+    flat_len = K * (K - 1) // 2
+
+    # Flatten the batch, scatter per-batch, then reshape back.
+    rates_flat = tf.reshape(rates, [-1, flat_len])
+    batch_size = tf.shape(rates_flat)[0]
+
+    def _build_one(rates_1d):
+        upper = tf.scatter_nd(upper_indices, rates_1d, shape=(K, K))
+        return upper + tf.linalg.matrix_transpose(upper)
+
+    out = tf.map_fn(_build_one, rates_flat)
+    return tf.reshape(out, tf.concat([batch_shape, [K, K]], axis=0))
+
+
+__all__ = ["DiscreteTraitModel"]

--- a/treeflow/evolution/traitio.py
+++ b/treeflow/evolution/traitio.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import csv
+import os
+import typing as tp
+
+import numpy as np
+import tensorflow as tf
+
+from treeflow import DEFAULT_FLOAT_DTYPE_TF
+
+PathLikeType = tp.Union[str, bytes, os.PathLike]
+TraitMappingType = tp.Mapping[str, str]
+
+DEFAULT_UNKNOWN_TOKENS: tp.FrozenSet[str] = frozenset({"?", "-", "NA", "N/A", ""})
+
+
+class TraitDataParseError(ValueError):
+    pass
+
+
+def parse_trait_csv(
+    filename: PathLikeType,
+    taxon_column: str = "taxon",
+    trait_column: str = "trait",
+) -> TraitMappingType:
+    """Read a two-column CSV of (taxon, trait) and return a mapping.
+
+    Parameters
+    ----------
+    filename : path-like
+        Path to a CSV file with at least the ``taxon_column`` and
+        ``trait_column`` headers.
+    taxon_column : str
+        Name of the column holding taxon labels.
+    trait_column : str
+        Name of the column holding discrete trait labels.
+
+    Returns
+    -------
+    Mapping[str, str]
+        Dictionary from taxon name to (string) trait label.
+    """
+    try:
+        with open(filename, newline="") as fh:
+            reader = csv.DictReader(fh)
+            if reader.fieldnames is None:
+                raise TraitDataParseError(
+                    f"Trait file {filename} is empty or has no header row"
+                )
+            missing = {taxon_column, trait_column} - set(reader.fieldnames)
+            if missing:
+                raise TraitDataParseError(
+                    f"Trait file {filename} missing required column(s): "
+                    f"{sorted(missing)}. Found: {reader.fieldnames}"
+                )
+            mapping: tp.Dict[str, str] = {}
+            for row_num, row in enumerate(reader, start=2):
+                taxon = row[taxon_column]
+                trait = row[trait_column]
+                if taxon in mapping:
+                    raise TraitDataParseError(
+                        f"Duplicate taxon {taxon!r} in trait file "
+                        f"{filename} at row {row_num}"
+                    )
+                mapping[taxon] = trait
+    except FileNotFoundError:
+        raise
+    except OSError as ex:
+        raise TraitDataParseError(f"Error reading trait file {filename}: {ex}")
+    return mapping
+
+
+class DiscreteTraitData:
+    """Discrete trait data at tips, for phylogeography / DTA.
+
+    Stores a mapping from taxon label to trait state, together with the
+    ordered set of possible trait states. Produces one-hot partials arrays
+    aligned to a caller-supplied taxon order, matching the layout consumed
+    by ``LeafCTMC`` and the phylogenetic likelihood machinery.
+
+    Parameters
+    ----------
+    csv_file : Optional[PathLikeType]
+        Path to a CSV file with at least ``taxon_column`` and
+        ``trait_column`` headers. Mutually exclusive with ``trait_mapping``.
+    trait_mapping : Optional[Mapping[str, str]]
+        Mapping from taxon label to trait state label.
+    states : Optional[Sequence[str]]
+        Ordered sequence of the full set of possible trait states. If
+        ``None``, the states are inferred from ``trait_mapping`` and sorted
+        lexicographically for reproducibility.
+    unknown_tokens : Iterable[str]
+        Trait-state labels interpreted as "unknown" — these tips receive
+        flat (uniform) partials rather than a one-hot vector. Defaults to
+        the common placeholders ``?``, ``-``, ``NA``, ``N/A``, and ``""``.
+    taxon_column, trait_column : str
+        Column names in the CSV (only used when ``csv_file`` is provided).
+    """
+
+    _trait_mapping: TraitMappingType
+
+    def __init__(
+        self,
+        csv_file: tp.Optional[PathLikeType] = None,
+        trait_mapping: tp.Optional[TraitMappingType] = None,
+        states: tp.Optional[tp.Sequence[str]] = None,
+        unknown_tokens: tp.Iterable[str] = DEFAULT_UNKNOWN_TOKENS,
+        taxon_column: str = "taxon",
+        trait_column: str = "trait",
+    ):
+        if (csv_file is None) == (trait_mapping is None):
+            raise ValueError(
+                "Exactly one of `csv_file` or `trait_mapping` must be supplied"
+            )
+        if csv_file is not None:
+            self._trait_mapping = parse_trait_csv(
+                csv_file,
+                taxon_column=taxon_column,
+                trait_column=trait_column,
+            )
+            self.csv_file = csv_file
+        else:
+            assert trait_mapping is not None
+            self._trait_mapping = dict(trait_mapping)
+            self.csv_file = None
+
+        self._unknown_tokens = frozenset(unknown_tokens)
+
+        observed_states = {
+            t for t in self._trait_mapping.values() if t not in self._unknown_tokens
+        }
+        if states is None:
+            self._states: tp.Tuple[str, ...] = tuple(sorted(observed_states))
+        else:
+            extra = observed_states - set(states)
+            if extra:
+                raise TraitDataParseError(
+                    f"Trait labels {sorted(extra)} not present in supplied "
+                    f"`states` list {list(states)}"
+                )
+            self._states = tuple(states)
+
+        if len(self._states) < 2:
+            raise TraitDataParseError(
+                f"Need at least two distinct trait states, got {self._states}"
+            )
+
+        self._state_index = {s: i for i, s in enumerate(self._states)}
+
+    @property
+    def states(self) -> tp.Tuple[str, ...]:
+        return self._states
+
+    @property
+    def n_states(self) -> int:
+        return len(self._states)
+
+    @property
+    def taxon_count(self) -> int:
+        return len(self._trait_mapping)
+
+    @property
+    def site_count(self) -> int:
+        """Always 1 — a discrete trait is a single-site "alignment" with K states.
+
+        Exposed for duck-type compatibility with :class:`Alignment` in the
+        phylogenetic likelihood pipeline.
+        """
+        return 1
+
+    @property
+    def trait_mapping(self) -> TraitMappingType:
+        return dict(self._trait_mapping)
+
+    def get_encoded_trait_array(
+        self, taxon_names: tp.Iterable[str]
+    ) -> np.ndarray:
+        """Return ``[1, n_taxa, K]`` partials array in the supplied taxon order.
+
+        Unknown states produce flat partials ``[1, 1, ..., 1]``; known states
+        produce one-hot vectors. The leading singleton axis is the "site"
+        axis, matching the ``[n_sites, n_taxa, n_states]`` layout produced
+        by :func:`encode_sequence_mapping` for nucleotide alignments.
+        """
+        taxon_names = list(taxon_names)
+        K = self.n_states
+        flat = np.ones(K, dtype=np.float64)
+        out = np.zeros((1, len(taxon_names), K), dtype=np.float64)
+        for i, taxon in enumerate(taxon_names):
+            if taxon not in self._trait_mapping:
+                raise TraitDataParseError(
+                    f"Taxon {taxon!r} requested but not present in trait data"
+                )
+            state = self._trait_mapping[taxon]
+            if state in self._unknown_tokens:
+                out[0, i, :] = flat
+            else:
+                out[0, i, self._state_index[state]] = 1.0
+        return out
+
+    def get_encoded_trait_tensor(
+        self,
+        taxon_names: tp.Iterable[str],
+        dtype: tf.DType = DEFAULT_FLOAT_DTYPE_TF,
+    ) -> tf.Tensor:
+        return tf.constant(self.get_encoded_trait_array(taxon_names), dtype=dtype)
+
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__name__}(taxon_count={self.taxon_count}, "
+            f"n_states={self.n_states}, states={list(self._states)})"
+        )
+
+
+__all__ = [
+    "DiscreteTraitData",
+    "TraitDataParseError",
+    "parse_trait_csv",
+    "DEFAULT_UNKNOWN_TOKENS",
+]

--- a/treeflow/model/phylo_model.py
+++ b/treeflow/model/phylo_model.py
@@ -27,7 +27,9 @@ from treeflow.evolution.substitution.base_substitution_model import (
 )
 from treeflow.evolution.substitution.nucleotide import JC, HKY, GTR
 from treeflow.evolution.substitution.nucleotide.gtr import GTR_RATE_ORDER
+from treeflow.evolution.substitution.discrete_trait.dta import DiscreteTraitModel
 from treeflow.evolution.seqio import Alignment, WeightedAlignment
+from treeflow.evolution.traitio import DiscreteTraitData
 from treeflow.distributions.discrete import FiniteDiscreteDistribution
 from treeflow.distributions.discretized import DiscretizedDistribution
 from treeflow.distributions.discrete_parameter_mixture import DiscreteParameterMixture
@@ -242,12 +244,21 @@ def get_tree_model(  # TODO: Support unrooted trees
 JC_KEY = "jc"
 GTR_KEY = "gtr"
 GTR_REL_KEY = "gtr_rel"
+DISCRETE_TRAIT_KEY = "discrete_trait"
 subst_model_classes = {JC_KEY: JC, "hky": HKY, GTR_KEY: GTR, GTR_REL_KEY: GTR}
 
 
 def get_subst_model(
     subst_model: str,
+    subst_params: tp.Optional[tp.Dict[str, object]] = None,
 ) -> EigendecompositionSubstitutionModel:  # TODO: Support non-eigen substitution models
+    if subst_model == DISCRETE_TRAIT_KEY:
+        if subst_params is None or "n_states" not in subst_params:
+            raise PhyloModelParseError(
+                "discrete_trait substitution model requires an `n_states` "
+                "integer in its parameter block"
+            )
+        return DiscreteTraitModel(int(subst_params["n_states"]))
     subst_model_class = subst_model_classes.get(subst_model, None)
     if subst_model_class is None:
         raise ValueError(f"Unknown substitution model {subst_model}")
@@ -278,6 +289,11 @@ def get_subst_model_params(
             ],
             axis=-1,
         )
+    elif subst_model == DISCRETE_TRAIT_KEY:
+        # n_states is a config value (required for model construction) and is
+        # not a parameter of the likelihood. Strip it so the remaining dict
+        # only contains the rate-matrix parameters passed to `eigen()`.
+        processed_params.pop("n_states", None)
     return processed_params, has_root
 
 
@@ -417,7 +433,7 @@ def get_sequence_distribution(  # TODO: Consider case where sequence is root?
 def phylo_model_to_joint_distribution(
     model: PhyloModel,
     initial_tree: TensorflowRootedTree,
-    initial_alignment: Alignment,
+    initial_alignment: tp.Union[Alignment, DiscreteTraitData],
     pattern_counts: tp.Optional[tf.Tensor] = None,
 ) -> JointDistributionCoroutine:
     def model_fn() -> tp.Generator[Distribution, tf.Tensor, None]:
@@ -434,7 +450,7 @@ def phylo_model_to_joint_distribution(
         subst_model_params, _ = yield from get_subst_model_params(
             model.subst_model, model.subst_params
         )
-        subst_model = get_subst_model(model.subst_model)
+        subst_model = get_subst_model(model.subst_model, model.subst_params)
 
         clock_model_params, clock_has_root_param = yield from get_params(
             model.clock_params


### PR DESCRIPTION
## Summary

Adds fixed-topology Bayesian phylogeography / discrete trait analysis (DTA) to TreeFlow: a K-state time-reversible substitution model, a trait-data CSV loader, `discrete_trait` support in the YAML model spec, and a new `treeflow_dta_hmc` CLI that runs HMC/NUTS on a time-tree with tip states.

Motivation: for large trees that are too expensive to infer topology and times over jointly in BEAST (e.g. real-time genomic surveillance settings with thousands of tips), a fixed-tree DTA analysis with NUTS is a fast way to infer migration rates, equilibrium frequencies, and ancestral states. This PR lays the groundwork; MASCOT-style structured-coalescent follow-on is then a natural next step in the same framework.

## What's included

**Core**
- `treeflow.evolution.substitution.discrete_trait.dta.DiscreteTraitModel(K)`: time-reversible K-state substitution model (Lemey et al. 2009 style), inherits `EigendecompositionSubstitutionModel` so it plugs into the existing transition-probability and pruning machinery without modification.
- `treeflow.evolution.traitio.DiscreteTraitData`: two-column CSV loader (`taxon,trait`), supports explicit or inferred state ordering and unknown-state partials. Duck-types as a one-site `Alignment` (`site_count = 1`) so it flows through the existing `LeafCTMC` / `phylogenetic_likelihood` pipeline unchanged.
- `discrete_trait` block in `treeflow.model.phylo_model`: `n_states` is a config int that is pulled at model-construction time and stripped from the params dict. The `clock.strict.clock_rate` scalar acts as the mean migration-rate multiplier.
- `treeflow_dta_hmc` CLI: fork of `treeflow_hmc` that takes `--traits` (CSV) instead of `--input` (alignment), validates that declared `n_states` matches observed states and that all tree taxa have trait assignments.

**Docs**
- `cli.treeflow_dta_hmc.rst` with complete YAML and CSV examples.
- `model-definition.md` extended with a `discrete_trait` section.
- API-reference stubs wired into the existing toctrees.
- Incidentally filled a pre-existing gap: `treeflow_hmc` CLI was not documented — now is.

**Tests (34 new, all passing)**
- `test/evolution/substitution/discrete_trait/test_dta.py` — 10 tests: shape/zero-row-sum for K ∈ {2,3,4,5,8}, time-reversibility, JC reduction at K=4, eigendecomposition round-trip, batched inputs, input validation.
- `test/evolution/test_traitio.py` — 14 tests: CSV round-trip, taxon reordering, unknown-state partials, explicit state ordering, error cases.
- `test/model/test_phylo_model_discrete_trait.py` — 8 tests: end-to-end from model dict through joint distribution sample + log_prob across K ∈ {3,4,6}.
- `test/cli/test_dta_hmc_cli.py` — 2 CLI tests.

## Test plan

- [x] `pytest test/evolution/ test/model/` — 86 passed (52 existing + 34 new), 0 regressions
- [x] `pytest test/` (excluding cli/acceleration markers) — 249 passed, 0 regressions
- [x] `pytest test/cli/test_dta_hmc_cli.py -m cli` — 2 passed end-to-end (NUTS on a 3-taxon tree completes in ~35s)
- [x] `sphinx-build -b html docs/source` — clean build, all new pages present
- [ ] Parameter recovery on simulated data (next step — not part of this PR)

## Followups not in this PR

1. **Validation against BEAST**: simulate from a known Q matrix under a known tree, fit with `treeflow_dta_hmc`, verify posterior means/CIs recover the generating rates. This is the natural next commit.
2. **Non-reversible K-state variant** via `tf.linalg.expm(Q*t)` for asymmetric migration rates (e.g. source/sink phylogeography).
3. **Ancestral-state reconstruction output** via the existing `sample_ctmc_preorder` primitive.
4. **MASCOT-style structured coalescent**: with the differentiable pruning and fixed-tree infrastructure in place, adding the per-segment ODE for lineage-state probabilities becomes a focused extension.