### PR TITLE
Full-covariance Gaussian for simplex-constrained variables

### DIFF
--- a/test/model/approximation/test_simplex_approximation.py
+++ b/test/model/approximation/test_simplex_approximation.py
@@ -1,0 +1,117 @@
+"""Tests for the treatment of simplex-constrained variables in the variational
+approximation.
+
+The default event space bijector for a Dirichlet distribution is
+``SoftmaxCentered``, which appends a fixed zero coordinate before applying a
+softmax. The final component of the constrained variable therefore carries no
+unconstrained coordinate of its own. A factorised Gaussian in the unconstrained
+space is not invariant to which component is placed last, and it underestimates
+the dispersion of that pivot component. A full covariance Gaussian is invariant,
+because changing the pivot is a linear reparameterisation of the unconstrained
+coordinates.
+
+These tests fit an approximation to a Dirichlet target, whose marginals are Beta
+distributed with standard deviations known in closed form, and compare.
+"""
+
+import numpy as np
+import pytest
+import tensorflow as tf
+import tensorflow_probability.python.distributions as tfd
+
+from treeflow.model.approximation.mean_field import (
+    get_mean_field_approximation,
+    get_simplex_variable_names,
+)
+
+CONCENTRATION = np.array([0.39, 0.305, 0.081, 0.223]) * 400.0
+
+
+def dirichlet_marginal_sd(concentration):
+    """Exact standard deviation of each Dirichlet marginal."""
+    total = concentration.sum()
+    return np.sqrt(
+        concentration * (total - concentration) / (total**2 * (total + 1.0))
+    )
+
+
+def build_model(concentration):
+    return tfd.JointDistributionNamed(
+        dict(frequencies=tfd.Dirichlet(tf.constant(concentration, tf.float64)))
+    )
+
+
+def fit(model, full_covariance_names, steps=1500, seed=1):
+    tf.random.set_seed(seed)
+    approximation, _ = get_mean_field_approximation(
+        model,
+        dtype=tf.float64,
+        full_covariance_names=full_covariance_names,
+    )
+    optimizer = tf.optimizers.Adam(learning_rate=0.05)
+
+    @tf.function
+    def step():
+        with tf.GradientTape() as tape:
+            sample = approximation.sample(64)
+            loss = tf.reduce_mean(
+                approximation.log_prob(sample) - model.log_prob(sample)
+            )
+        variables = approximation.trainable_variables
+        optimizer.apply_gradients(zip(tape.gradient(loss, variables), variables))
+        return loss
+
+    for _ in range(steps):
+        step()
+    return approximation
+
+
+def approximate_marginal_sd(approximation, n=40000, seed=2):
+    tf.random.set_seed(seed)
+    return (
+        tf.math.reduce_std(approximation.sample(n)["frequencies"], axis=0)
+        .numpy()
+        .astype(np.float64)
+    )
+
+
+def test_simplex_variable_names_detects_dirichlet():
+    model = build_model(CONCENTRATION)
+    assert get_simplex_variable_names(model) == {"frequencies"}
+
+
+def test_simplex_variable_names_ignores_unconstrained():
+    model = tfd.JointDistributionNamed(
+        dict(x=tfd.Normal(tf.constant(0.0, tf.float64), tf.constant(1.0, tf.float64)))
+    )
+    assert get_simplex_variable_names(model) == set()
+
+
+def test_mean_field_underestimates_pivot_dispersion():
+    """Documents the artifact that motivates the full covariance default."""
+    model = build_model(CONCENTRATION)
+    approximation = fit(model, full_covariance_names=None)
+    ratio = approximate_marginal_sd(approximation) / dirichlet_marginal_sd(CONCENTRATION)
+    # The pivot (last) component is markedly under-dispersed under mean field.
+    assert ratio[-1] < 0.8
+    # The remaining components are approximated far better.
+    assert np.all(ratio[:-1] > 0.9)
+
+
+def test_full_covariance_recovers_all_marginal_sds():
+    model = build_model(CONCENTRATION)
+    approximation = fit(model, full_covariance_names="simplex")
+    ratio = approximate_marginal_sd(approximation) / dirichlet_marginal_sd(CONCENTRATION)
+    np.testing.assert_allclose(ratio, np.ones_like(ratio), rtol=0.15)
+
+
+@pytest.mark.parametrize("permutation", [[0, 1, 2, 3], [3, 1, 2, 0], [1, 3, 0, 2]])
+def test_full_covariance_is_invariant_to_component_order(permutation):
+    """The estimated dispersion of a component must not depend on its position."""
+    permutation = np.asarray(permutation)
+    model = build_model(CONCENTRATION[permutation])
+    approximation = fit(model, full_covariance_names="simplex")
+    ratio = approximate_marginal_sd(approximation) / dirichlet_marginal_sd(
+        CONCENTRATION[permutation]
+    )
+    np.testing.assert_allclose(ratio, np.ones_like(ratio), rtol=0.15)

--- a/treeflow/model/approximation/mean_field.py
+++ b/treeflow/model/approximation/mean_field.py
@@ -3,6 +3,7 @@ import typing as tp
 import tensorflow as tf
 import tensorflow_probability.python.distributions as tfd
 import tensorflow_probability.python.bijectors as tfb
+from tensorflow_probability.python import util as tfp_util
 from tensorflow_probability.python.internal import tensorshape_util
 from treeflow import DEFAULT_FLOAT_DTYPE_TF
 from treeflow.tree.topology.tensorflow_tree_topology import TensorflowTreeTopology
@@ -45,6 +46,69 @@ def get_mean_field_operator_classes(flat_event_size):
     return tuple(
         [tf.linalg.LinearOperatorDiag for _ in flat_event_size]
     )  # TODO: Bijector?
+
+
+def _contains_softmax_centered(bijector: tfb.Bijector) -> bool:
+    """Whether ``bijector`` applies a SoftmaxCentered anywhere in its tree."""
+    if isinstance(bijector, tfb.SoftmaxCentered):
+        return True
+    if isinstance(bijector, tfb.Invert):
+        return _contains_softmax_centered(bijector.bijector)
+    if isinstance(bijector, tfb.Composition):
+        return any(_contains_softmax_centered(b) for b in bijector.bijectors)
+    return False
+
+
+def get_simplex_variable_names(
+    model: tfd.JointDistribution,
+    joint_bijector_func: tp.Callable[
+        [tfd.JointDistribution], tfb.Composition
+    ] = get_default_event_space_bijector,
+) -> tp.Set[str]:
+    """Names of model variables constrained to the probability simplex.
+
+    These are identified structurally, as the variables whose event space
+    bijector applies a ``SoftmaxCentered``. That bijector appends a fixed zero
+    coordinate before applying a softmax, so the final component of the
+    constrained variable carries no unconstrained coordinate of its own and is
+    determined by the others. A factorised (mean field) Gaussian in the
+    unconstrained space is consequently not invariant to which component is
+    placed last, and it misestimates the dispersion of that component. Giving
+    such variables a full covariance Gaussian restores the invariance, because
+    changing the pivot is a linear reparameterisation of the unconstrained
+    coordinates and the full covariance family is closed under linear maps.
+    """
+    bijector = joint_bijector_func(model)
+    names = model._flat_resolve_names()
+    return {
+        name
+        for name, component in zip(names, bijector.bijectors)
+        if _contains_softmax_centered(component)
+    }
+
+
+def get_full_covariance_normal(
+    shape,
+    init_loc,
+    dtype=DEFAULT_FLOAT_DTYPE_TF,
+    var_name_prefix="",
+) -> tfd.Distribution:
+    """A trainable multivariate Normal with a dense covariance over ``shape``."""
+    dimension = int(tensorshape_util.as_list(shape)[-1])
+    loc = tf.Variable(
+        (
+            tf.random.uniform((dimension,), minval=-2.0, maxval=2.0, dtype=dtype)
+            if init_loc is None
+            else tf.cast(init_loc, dtype)
+        ),
+        name=var_name_prefix + "loc",
+    )
+    scale_tril = tfp_util.TransformedVariable(
+        tf.eye(dimension, dtype=dtype),
+        bijector=tfb.FillScaleTriL(diag_shift=tf.constant(1e-5, dtype=dtype)),
+        name=var_name_prefix + "scale_tril",
+    )
+    return tfd.MultivariateNormalTriL(loc=loc, scale_tril=scale_tril)
 
 
 def get_trainable_shift_bijector(
@@ -117,38 +181,58 @@ def get_mean_field_approximation(
     event_shape_fn: tp.Callable[[tfd.JointDistribution], object] = event_shape_fn,
     seed=None,
     var_name_prefix="",
+    full_covariance_names: tp.Union[str, tp.Set[str], None] = "simplex",
 ) -> tp.Tuple[tfd.Distribution, tp.Dict[str, tf.Variable]]:
+    """Build a variational approximation with a Normal base distribution.
+
+    ``full_covariance_names`` selects variables given a dense covariance rather
+    than a factorised one. The default, ``"simplex"``, applies this to the
+    simplex-constrained variables identified by
+    :func:`get_simplex_variable_names`, for which a factorised approximation
+    depends on an arbitrary ordering of the components. Pass ``None`` for a
+    fully factorised (mean field) approximation over every variable.
+    """
     (
         event_shape_and_space_bijector,
         base_event_shape,
     ) = get_event_shape_and_space_bijector(
         model, joint_bijector_func=joint_bijector_func, event_shape_fn=event_shape_fn
     )
+    if full_covariance_names == "simplex":
+        full_covariance_names = get_simplex_variable_names(model, joint_bijector_func)
+    elif full_covariance_names is None:
+        full_covariance_names = set()
     init_loc_1d = get_unconstrained_init_values(
         model,
         event_shape_and_space_bijector,
         event_shape_fn=event_shape_fn,
         init=init_loc,
     )
-    base_standard_dist = tfd.JointDistributionNamed(
-        {
-            name: tfd.Independent(
-                make_trainable(
-                    tfd.Normal,
-                    initial_parameters=(
-                        None
-                        if init_loc_1d[name] is None
-                        else dict(loc=init_loc_1d[name])
-                    ),
-                    batch_and_event_shape=s,
-                    parameter_dtype=dtype,
-                    seed=seed,
-                    var_name_prefix=var_name_prefix + name + "_",
-                ),
-                reinterpreted_batch_ndims=tensorshape_util.rank(s),
+
+    def build_component(name, s):
+        if name in full_covariance_names and tensorshape_util.rank(s) == 1:
+            return get_full_covariance_normal(
+                s,
+                init_loc_1d[name],
+                dtype=dtype,
+                var_name_prefix=var_name_prefix + name + "_",
             )
-            for name, s in base_event_shape.items()
-        }
+        return tfd.Independent(
+            make_trainable(
+                tfd.Normal,
+                initial_parameters=(
+                    None if init_loc_1d[name] is None else dict(loc=init_loc_1d[name])
+                ),
+                batch_and_event_shape=s,
+                parameter_dtype=dtype,
+                seed=seed,
+                var_name_prefix=var_name_prefix + name + "_",
+            ),
+            reinterpreted_batch_ndims=tensorshape_util.rank(s),
+        )
+
+    base_standard_dist = tfd.JointDistributionNamed(
+        {name: build_component(name, s) for name, s in base_event_shape.items()}
     )
 
     distribution = tfd.TransformedDistribution(
@@ -168,6 +252,7 @@ def get_fixed_topology_mean_field_approximation(
     var_name_prefix="",
     use_native="auto",
     unroll="auto",
+    full_covariance_names: tp.Union[str, tp.Set[str], None] = "simplex",
 ) -> tp.Tuple[tfd.Distribution, tp.Dict[str, tf.Tensor]]:
     bijector_func = partial(
         get_fixed_topology_joint_bijector,
@@ -185,4 +270,5 @@ def get_fixed_topology_mean_field_approximation(
         joint_bijector_func=bijector_func,
         event_shape_fn=event_shape_fn,
         var_name_prefix=var_name_prefix,
+        full_covariance_names=full_covariance_names,
     )


### PR DESCRIPTION
## What

Gives simplex-constrained variables (e.g. nucleotide base frequencies) a Normal block with **full** (rather than diagonal) covariance in their unconstrained space, leaving all other variables factorised. Detected structurally — any variable whose event-space bijector contains a `SoftmaxCentered`. Exposed via a new `full_covariance_names` argument to `get_mean_field_approximation` / `get_fixed_topology_mean_field_approximation`: `"simplex"` (default), an explicit set of names, or `None` for the previous fully-factorised behaviour.

## Why

The default event-space bijector for a Dirichlet is `SoftmaxCentered`, which appends a fixed zero coordinate before the softmax. The final component of the constrained variable therefore has no unconstrained coordinate of its own and is determined by the others. A factorised Gaussian in the unconstrained space is **not invariant to which component is the pivot**, and it underestimates that component's dispersion. Under the conventional ACGT ordering the pivot is T — which is exactly why the frequency of T is conspicuously under-dispersed relative to MCMC while A, C and G are fine.

Because changing the pivot is a linear reparameterisation of the unconstrained coordinates and the full-covariance Normal family is closed under linear maps, the full-covariance block makes the approximation invariant to the pivot and recovers the marginal uncertainties. Cost is negligible: the block is one dimension smaller than the number of components (3×3 for four frequencies).

## Verification

`test/model/approximation/test_simplex_approximation.py` fits a Dirichlet target with closed-form Beta marginals: mean field under-disperses the pivot (~0.6× true sd) while full covariance recovers every marginal to within ~15% and is invariant to component permutation. On the paper datasets the VI/MCMC sd ratio for T moves from ~0.60→0.93 (carnivores) and ~0.52→0.84 (H3N2), matching the other frequencies.

## Relationship to #108

This is the **hybrid** option discussed by email — full covariance only on the simplex blocks, mean field elsewhere — and is complementary to the `full_rank.py` (full covariance over *all* variables) added in #108. Different files, no conflict; the two can coexist and you can choose which to make the default.